### PR TITLE
add env first

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
     steps:
       - uses: actions/checkout@v4
 
@@ -18,5 +20,3 @@ jobs:
       - run: pip install mkdocs mkdocs-material pymdown-extensions
 
       - run: mkdocs gh-deploy --force --remote-branch gh-pages --remote-name origin
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
This pull request updates the way the `GITHUB_TOKEN` environment variable is set in the `docs.yml` GitHub Actions workflow. Instead of specifying the token for a single step, it now sets it at the job level for the entire deploy job, simplifying environment variable management.

Workflow configuration improvements:

* Set the `GITHUB_TOKEN` environment variable at the job level in the `deploy` job, rather than at the individual step level, in `.github/workflows/docs.yml`. [[1]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR11-R12) [[2]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL21-L22)