### PR TITLE
Xiangyu/generalize scaling

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,56 +2,64 @@
 
 ## Introduction
 
-SPHinXsim is a Python and LLM interface for building and running multi-physics SPH simulations on top of the SPHinXsys C++ library.
+SPHinXsim is a Python and LLM-facing workflow for building, validating, updating, and running SPH simulations on top of the SPHinXsys C++ library.
 
-The project focuses on making simulation setup easier without losing scientific structure. Instead of writing low-level C++ for every case, users can describe a scenario in natural language, generate a structured JSON configuration, validate it against strict schemas, and run it through the SPHinXsys backend.
+The project is designed around explicit simulation configuration rather than opaque prompt-only execution. A user can describe a scenario in natural language, generate a structured JSON config, revise that config with further instructions, validate it against strict schemas, and execute it through the SPHinXsys backend.
 
 ## What this repository provides
 
-- A Python package (`sphinxsim`) with CLI and LLM integration.
-- Pydantic-based simulation schemas for robust config validation.
-- C++ binding integration with SPHinXsys simulation kernels.
-- Documentation and tests for development and user workflows.
+- A Python package, `sphinxsim`, with a CLI for config generation, update, validation, and execution.
+- Pydantic-based schemas for geometry, materials, particle generation, solver settings, observers, constraints, and recording options.
+- LLM adapters with a local mock backend by default and OpenAI-backed generation when configured.
+- Native C++ bindings and simulation builders that bridge validated JSON configs to SPHinXsys runtime components.
+- Tests and documentation covering schema rules, CLI behavior, and integrated simulation workflows.
 
 ## Core workflow
 
-The intended user loop is:
+The current user loop is:
 
 1. Describe a simulation in natural language.
-2. Generate JSON config (`sphinxsim generate`).
-3. Validate schema and physical consistency (`sphinxsim validate`).
-4. Run simulation (`sphinxsim run`).
-5. Iterate on parameters and rerun.
+2. Generate a JSON config with `sphinxsim generate`.
+3. Refine an existing config with `sphinxsim update`.
+4. Validate structure and cross-field consistency with `sphinxsim validate`.
+5. Run the validated case with `sphinxsim run`.
+6. Iterate on geometry, materials, solver settings, and rerun.
 
-This structure keeps configuration explicit and reproducible while still allowing faster setup with LLM assistance.
+This keeps simulation inputs reproducible and reviewable while still allowing fast iteration through LLM assistance.
 
 ## High-level architecture
 
 - `sphinxsim/cli.py`:
- Command-line entry point for generate/validate/run.
+  Command-line entry point for `generate`, `update`, `validate`, and `run`. It resolves project-local paths, validates configs before execution, and routes runtime output into project-managed build directories.
 - `sphinxsim/config/schemas.py`:
- Pydantic models for domain bounds, fluid bodies, solid bodies, observers, solver options, and consistency checks.
+  Defines the top-level `SimulationConfig` and the typed config surface for system domains, global resolution, shapes, aligned boxes, particle generation, fluid bodies, continuum bodies, solid bodies, boundary conditions, observers, restart settings, body constraints, and extra state recording.
 - `sphinxsim/llm/`:
- LLM backends (including OpenAI and mock mode) that transform natural-language prompts into schema-compliant configs.
-- `sphinxsim/sph_simulation/` and bindings:
- Bridge to compiled SPHinXsys C++ components used at runtime.
+  Provides LLM backends that translate natural-language prompts into schema-compliant configs. The default mock backend supports deterministic local testing, while the OpenAI backend can be enabled with environment variables such as `SPHINXSIM_LLM_PROVIDER`, `OPENAI_API_KEY`, and `OPENAI_MODEL`.
+- `sphinxsim/sph_simulation/` and native bindings:
+  Build and load SPHinXsys-backed simulation objects from validated JSON, including fluid and continuum-oriented workflows exposed through the Python package.
 
-## Current scope and direction
+## Current capabilities
 
-SPHinXsim is currently a strong foundation for:
+SPHinXsim currently supports a broader config surface than a basic fluid-only demo workflow:
 
-- Fluid-focused simulation setup.
-- Config-first simulation reproducibility.
-- Python-driven experimentation around SPHinXsys.
+- Fluid dynamics configurations with typed fluid materials, inflow boundary conditions, observers, and solver controls.
+- Continuum dynamics configurations with continuum material models and dedicated continuum solver parameters.
+- Solid boundary/body definitions required by the current validation and simulation builders.
+- Config-driven geometry composition using domains, shapes, aligned boxes, transforms, and particle-generation settings.
+- Incremental config editing through the CLI update command instead of regenerating cases from scratch.
 
-It is designed to grow toward richer multi-physics coverage (for example, more complete solid and FSI pipelines), stronger benchmark suites, and broader end-to-end automation from prompt to validated simulation artifacts.
+The repository remains config-first: natural-language generation is useful for initialization and revision, but the validated JSON artifact is the authoritative simulation input.
+
+## Current direction
+
+The codebase is positioned for richer multi-physics growth while staying strict about validation boundaries. In practice, that means expanding benchmark coverage, continuing to improve continuum and coupled workflows, and strengthening the path from prompt to executable, testable simulation assets.
 
 ## Why this project matters
 
-SPHinXsys is powerful but can be complex to access for rapid iteration. SPHinXsim narrows that gap by combining:
+SPHinXsys provides strong performance and physical modeling, but direct setup can be expensive for rapid iteration. SPHinXsim narrows that gap by combining:
 
-- Performance and physical modeling from SPHinXsys.
-- Usability and orchestration in Python.
-- Fast scenario prototyping through LLM-assisted config generation.
+- A structured Python interface for orchestration and validation.
+- LLM-assisted config authoring and revision.
+- Native execution against SPHinXsys kernels once the config is validated.
 
-Together, this enables a practical path from idea to executable simulation with clearer structure, stronger validation, and lower onboarding friction.
+Together, these pieces provide a practical path from idea to executable simulation with clearer structure, stronger reproducibility, and lower onboarding friction.

--- a/sphinxsim/config/schemas.py
+++ b/sphinxsim/config/schemas.py
@@ -25,12 +25,17 @@ class CharacteristicDimensionName(str, Enum):
     LENGTH = "Length"
     MASS = "Mass"
     TIME = "Time"
+    TEMPERATURE = "Temperature"
+    ELECTRIC_CURRENT = "ElectricCurrent"
+    AMOUNT_OF_SUBSTANCE = "AmountOfSubstance"
+    LUMINOUS_INTENSITY = "LuminousIntensity"
     DENSITY = "Density"
     PRESSURE = "Pressure"
     STRESS = "Stress"
     VISCOSITY = "Viscosity"
     VELOCITY = "Velocity"
     SPEED = "Speed"
+    ANGULAR_VELOCITY = "AngularVelocity"
     GRAVITY = "Gravity"
     ACCELERATION = "Acceleration"
     DIMENSIONLESS = "Dimensionless"
@@ -314,6 +319,7 @@ class MaterialConfig(BaseModel):
 
     density: Optional[float] = Field(default=None, gt=0)
     sound_speed: Optional[float] = Field(default=None, gt=0)
+    maximum_velocity: Optional[float] = Field(default=None, gt=0)
     viscosity: Optional[float] = Field(default=None, gt=0)
 
     youngs_modulus: Optional[float] = Field(default=None, gt=0)
@@ -324,8 +330,12 @@ class MaterialConfig(BaseModel):
     @model_validator(mode="after")
     def _validate_material_by_type(self) -> "MaterialConfig":
         if self.type == MaterialType.WEAKLY_COMPRESSIBLE_FLUID:
-            if self.density is None or self.sound_speed is None:
-                raise ValueError("weakly_compressible_fluid requires density and sound_speed")
+            if self.density is None:
+                raise ValueError("weakly_compressible_fluid requires density")
+            if self.sound_speed is None and self.maximum_velocity is None:
+                raise ValueError(
+                    "weakly_compressible_fluid requires sound_speed or maximum_velocity"
+                )
         elif self.type == MaterialType.RIGID_BODY:
             pass
         elif self.type == MaterialType.J2_PLASTICITY:
@@ -547,6 +557,11 @@ class SimulationConfig(BaseModel):
                 raise ValueError("body_constraints body_name must reference an existing continuum/solid body")
             if constraint.region is not None and constraint.region not in shape_names:
                 raise ValueError("body_constraints region must reference an existing shape name")
+
+        # Simbody constraints require restart section to exist at runtime.
+        if any(constraint.type == BodyConstraintType.SIMBODY for constraint in self.body_constraints):
+            if self.solver_parameters.restart is None:
+                raise ValueError("simbody body_constraints require solver_parameters.restart")
 
         # Dimensional consistency if system_domain is present
         if self.geometries.system_domain is not None:

--- a/sphinxsim/sph_simulation/base_simulation_builder.cpp
+++ b/sphinxsim/sph_simulation/base_simulation_builder.cpp
@@ -12,7 +12,40 @@ bool ScalingConfig::is_number(const std::string &s) const
     return !s.empty() && std::all_of(s.begin(), s.end(), ::isdigit);
 }
 //=================================================================================================//
+bool ScalingConfig::is_array_float(const json &arr) const
+{
+    if (!arr.is_array())
+        return false;
+
+    const int dim = static_cast<int>(Vecd::RowsAtCompileTime);
+    if (static_cast<int>(arr.size()) != dim)
+        return false;
+
+    return std::all_of(arr.begin(), arr.end(), [](const json &value)
+                       { return value.is_number_float(); });
+}
+//=================================================================================================//
 Real ScalingConfig::resolve(const json &j, const std::string &path) const
+{
+    const json *current = resolveNode(j, path);
+
+    if (current->is_number_float())
+        return ABS(current->get<Real>());
+
+    if (is_array_float(*current))
+    {
+        Vecd v = Vecd::Zero();
+        for (int i = 0; i < Vecd::RowsAtCompileTime; ++i)
+            v[i] = (*current)[i].get<Real>();
+        return v.norm();
+    }
+
+    throw std::runtime_error(
+        "Resolved value must be either a numeric scalar or a floating array with exactly " +
+        std::to_string(Vecd::RowsAtCompileTime) + " entries");
+}
+//=================================================================================================//
+const json *ScalingConfig::resolveNode(const json &j, const std::string &path) const
 {
     const json *current = &j;
 
@@ -79,10 +112,7 @@ Real ScalingConfig::resolve(const json &j, const std::string &path) const
         i = dot + 1;
     }
 
-    if (!current->is_number())
-        throw std::runtime_error("Resolved value is not numeric");
-
-    return current->get<Real>();
+    return current;
 }
 //=================================================================================================//
 const json *ScalingConfig::find_in_array(
@@ -173,6 +203,11 @@ ScalingConfig::ScalingConfig(const json &config)
         std::cout << "Using default scaling (no scaling)." << std::endl;
     }
     std::cout << "------------------------------------------------------------" << std::endl;
+}
+//=================================================================================================//
+bool ScalingConfig::isScalingEnabled() const
+{
+    return scaling_refs_.any();
 }
 //=================================================================================================//
 UnitMetrics ScalingConfig::getUnitMetrics(std::string unit_name, bool is_required) const
@@ -298,10 +333,16 @@ Real ScalingConfig::getScalingRef(const std::string &unit_name, bool is_required
 //=================================================================================================//
 Vecd ScalingConfig::jsonToVecd(const nlohmann::json &arr, const std::string &unit_name) const
 {
+    if (!is_array_float(arr))
+    {
+        throw std::runtime_error(
+            "ScalingConfig::jsonToVecd: expected a numeric array with exactly " +
+            std::to_string(Vecd::RowsAtCompileTime) + " entries.");
+    }
+
     Vecd v = Vecd::Zero();
-    const int dim = static_cast<int>(Vecd::RowsAtCompileTime);
     Real scaling_ref = getScalingRef(unit_name);
-    for (int i = 0; i < std::min(dim, static_cast<int>(arr.size())); ++i)
+    for (int i = 0; i < Vecd::RowsAtCompileTime; ++i)
         v[i] = arr[i].get<Real>() / scaling_ref;
     return v;
 }

--- a/sphinxsim/sph_simulation/base_simulation_builder.h
+++ b/sphinxsim/sph_simulation/base_simulation_builder.h
@@ -62,6 +62,7 @@ class ScalingConfig
 {
   public:
     ScalingConfig(const json &config);
+    bool isScalingEnabled() const;
     Vecd jsonToVecd(const nlohmann::json &arr, const std::string &unit_name) const;
     Real jsonToReal(const json &j, const std::string &unit_name) const;
     Real getScalingRef(const std::string &unit_name, bool is_required = true) const;
@@ -80,6 +81,8 @@ class ScalingConfig
     void computeScaling();
     bool isSameOrderOfMagnitude(const Real a, const Real b) const;
     bool is_number(const std::string &s) const;
+    bool is_array_float(const json &arr) const;
+    const json *resolveNode(const json &j, const std::string &path) const;
     const json *find_in_array(const json &arr, const std::string &key, const std::string &value) const;
     Real resolve(const json &j, const std::string &path) const;
 };

--- a/sphinxsim/sph_simulation/continuum_simulation_builder.cpp
+++ b/sphinxsim/sph_simulation/continuum_simulation_builder.cpp
@@ -14,6 +14,7 @@ void ContinuumSimulationBuilder::buildSimulation(SPHSimulation &sim, const json 
     SPHSystem &sph_system = sim.defineSPHSystem();
     EntityManager &config_manager = sim.getConfigManager();
     RecordingBuilder &recording_builder = sim.getRecordingBuilder();
+    ScalingConfig &scaling_config = config_manager.getEntity<ScalingConfig>("ScalingConfig");
     //----------------------------------------------------------------------
     //	Creating bodies with inital shape, materials and particles.
     //----------------------------------------------------------------------
@@ -64,8 +65,7 @@ void ContinuumSimulationBuilder::buildSimulation(SPHSimulation &sim, const json 
 
     auto &continuum_solver_parameters = config_manager.getEntity<
         ContinuumSolverParameters>("ContinuumSolverParameters");
-    Fluid &continuum_eos = DynamicCast<Fluid>(this, continuum_body.getBaseMaterial());
-    const Real U_ref = continuum_eos.ReferenceSoundSpeed() / 10.0; // c_f = 10 * U_ref => U_ref = c_f / 10
+    Real U_ref = scaling_config.getScalingRef("Velocity");
     auto &continuum_advection_time_step = main_methods.addReduceDynamics<
         fluid_dynamics::AdvectionTimeStepCK>(continuum_body, U_ref, continuum_solver_parameters.advection_cfl_);
     auto &continuum_acoustic_time_step = main_methods.addReduceDynamics<

--- a/sphinxsim/sph_simulation/fluid_simulation_builder.cpp
+++ b/sphinxsim/sph_simulation/fluid_simulation_builder.cpp
@@ -71,8 +71,7 @@ void FluidSimulationBuilder::buildSimulation(SPHSimulation &sim, const json &con
         config_manager, main_methods, fluid_inner, fluid_wall_contact);
 
     auto &fluid_solver_config = config_manager.getEntity<FluidSolverConfig>("FluidSolverConfig");
-    Fluid &fluid_material = DynamicCast<Fluid>(this, fluid_body.getBaseMaterial());
-    const Real U_ref = fluid_material.ReferenceSoundSpeed() / 10.0; // c_f = 10 * U_ref => U_ref = c_f / 10
+    Real U_ref = scaling_config.getScalingRef("Velocity");
     auto &fluid_advection_time_step = main_methods.addReduceDynamics<fluid_dynamics::AdvectionTimeStepCK>(
         fluid_body, U_ref, fluid_solver_config.advection_cfl_);
     auto &fluid_acoustic_time_step = main_methods.addReduceDynamics<fluid_dynamics::AcousticTimeStepCK<>>(

--- a/sphinxsim/sph_simulation/fluid_simulation_builder.cpp
+++ b/sphinxsim/sph_simulation/fluid_simulation_builder.cpp
@@ -90,7 +90,6 @@ void FluidSimulationBuilder::buildSimulation(SPHSimulation &sim, const json &con
     auto &advection_step = time_stepper.addTriggerByInterval(fluid_advection_time_step.exec());
     auto &state_recording_trigger = time_stepper.addTriggerByInterval(solver_common_config.output_interval_);
     time_stepper.setScreeningInterval(solver_common_config.screen_interval_);
-    Real time_scaling_ref = scaling_config.getScalingRef("Time");
     //----------------------------------------------------------------------
     //	Define preparation or initialization step before the main integration.
     //----------------------------------------------------------------------
@@ -130,7 +129,7 @@ void FluidSimulationBuilder::buildSimulation(SPHSimulation &sim, const json &con
         });
 
     simulation_pipeline.main_steps.push_back( // advection or particle configuration step
-        [&, time_scaling_ref]()
+        [&]()
         {
             if (advection_step(fluid_advection_time_step))
             {
@@ -141,10 +140,10 @@ void FluidSimulationBuilder::buildSimulation(SPHSimulation &sim, const json &con
                 {
                     std::cout << std::fixed << std::setprecision(9)
                               << "N=" << time_stepper.getIterationStep()
-                              << "  Time = " << time_stepper.getPhysicalTime() * time_scaling_ref
-                              << "  advection_dt = " << advection_step.getInterval() * time_scaling_ref
+                              << "  Time = " << time_stepper.getPhysicalTimeWithScalingRef()
+                              << "  advection_dt = " << advection_step.getIntervalWithScalingRef()
                               << "(scaled: " << advection_step.getInterval() << "),"
-                              << "  acoustic_dt = " << time_stepper.getGlobalTimeStepSize() * time_scaling_ref
+                              << "  acoustic_dt = " << time_stepper.getGlobalTimeStepSizeWithScalingRef()
                               << "(scaled: " << time_stepper.getGlobalTimeStepSize() << ")"
                               << "\n";
                 }

--- a/sphinxsim/sph_simulation/material_builder.cpp
+++ b/sphinxsim/sph_simulation/material_builder.cpp
@@ -13,7 +13,17 @@ void MaterialBuilder::addMaterial(EntityManager &config_manager, SPHBody &sph_bo
     if (type == "weakly_compressible_fluid")
     {
         Real density = scaling_config.jsonToReal(config.at("density"), "Density");
-        Real sound_speed = scaling_config.jsonToReal(config.at("sound_speed"), "Speed");
+        Real sound_speed = 0.0;
+        if (config.contains("sound_speed"))
+        {
+            sound_speed = scaling_config.jsonToReal(config.at("sound_speed"), "Speed");
+        }
+        else
+        {
+            Real u_max = scaling_config.jsonToReal(config.at("maximum_velocity"), "Velocity");
+            sound_speed = 10.0 * u_max;
+        }
+
         if (config.contains("viscosity"))
         {
             Real viscosity = scaling_config.jsonToReal(config.at("viscosity"), "Viscosity");

--- a/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/all_shared_physical_dynamics_ck.h
+++ b/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/all_shared_physical_dynamics_ck.h
@@ -41,6 +41,5 @@
 #include "interaction_algorithms_ck.hpp"
 #include "particle_functors_ck.h"
 #include "particle_sort_ck.hpp"
-#include "sph_solver.h"
 
 #endif // ALL_SHARED_PHYSICAL_DYNAMICS_CK_H

--- a/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/sph_solver.cpp
+++ b/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/sph_solver.cpp
@@ -6,10 +6,7 @@ namespace SPH
 {
 //=================================================================================================//
 TimeStepper::TimeStepper(SPHSystem &sph_system)
-    : global_dt_(0.0)
-{
-    sv_physical_time_ = &sph_system.svPhysicalTime();
-}
+    : global_dt_(0.0), sv_physical_time_(&sph_system.svPhysicalTime()){}
 //=================================================================================================//
 void TimeStepper::setRestartStep(UnsignedInt restart_step)
 {
@@ -27,8 +24,9 @@ bool TimeStepper::TriggerByPhysicalTime::operator()()
     return sv_physical_time_->getValue() > trigger_time_;
 }
 //=================================================================================================//
-TimeStepper::TriggerByInterval::TriggerByInterval(Real initial_interval)
-    : present_time_(0.0), interval_(initial_interval) {}
+TimeStepper::TriggerByInterval::TriggerByInterval(TimeStepper &time_stepper, Real initial_interval)
+    : sv_physical_time_(time_stepper.sv_physical_time_),
+      present_time_(0.0), interval_(initial_interval) {}
 //=================================================================================================//
 bool TimeStepper::TriggerByInterval::operator()(BaseDynamics<Real> &interval_evaluator)
 {
@@ -54,6 +52,10 @@ bool TimeStepper::TriggerByInterval::operator()()
 Real TimeStepper::TriggerByInterval::getInterval() const
 {
     return interval_;
+}
+Real TimeStepper::TriggerByInterval::getIntervalWithScalingRef() const
+{
+    return getInterval() * sv_physical_time_->getScalingRef();
 }
 //=================================================================================================//
 void TimeStepper::TriggerByInterval::incrementPresentTime(Real dt)
@@ -97,7 +99,7 @@ TimeStepper::TriggerByInterval &TimeStepper::addTriggerByInterval(Real initial_i
 {
 
     TriggerByInterval *interval_executor =
-        execution_by_interval_keeper_.createPtr<TriggerByInterval>(initial_interval);
+        execution_by_interval_keeper_.createPtr<TriggerByInterval>(*this, initial_interval);
     interval_executers_.push_back(interval_executor);
     return *interval_executor;
 }
@@ -129,6 +131,16 @@ Real TimeStepper::getPhysicalTime()
 Real TimeStepper::getGlobalTimeStepSize()
 {
     return global_dt_;
+}
+//=================================================================================================//
+Real TimeStepper::getPhysicalTimeWithScalingRef()
+{
+    return getGlobalTimeStepSize() * sv_physical_time_->getScalingRef();
+}
+//=================================================================================================//
+Real TimeStepper::getGlobalTimeStepSizeWithScalingRef()
+{
+    return getGlobalTimeStepSize() * sv_physical_time_->getScalingRef();
 }
 //=================================================================================================//
 } // namespace SPH

--- a/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/sph_solver.cpp
+++ b/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/sph_solver.cpp
@@ -135,7 +135,7 @@ Real TimeStepper::getGlobalTimeStepSize()
 //=================================================================================================//
 Real TimeStepper::getPhysicalTimeWithScalingRef()
 {
-    return getGlobalTimeStepSize() * sv_physical_time_->getScalingRef();
+    return sv_physical_time_->getValueWithScalingRef();
 }
 //=================================================================================================//
 Real TimeStepper::getGlobalTimeStepSizeWithScalingRef()

--- a/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/sph_solver.h
+++ b/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/sph_solver.h
@@ -44,6 +44,8 @@ class TimeStepper
     void setPhysicalTime(Real time);
     Real getPhysicalTime();
     Real getGlobalTimeStepSize();
+    Real getPhysicalTimeWithScalingRef();
+    Real getGlobalTimeStepSizeWithScalingRef();
     Real incrementPhysicalTime(Real global_time_step);
     Real incrementPhysicalTime(BaseDynamics<Real> &step_evaluator);
     UnsignedInt getIterationStep() const { return iteration_step_; }
@@ -119,13 +121,15 @@ class TimeStepper
     class TriggerByInterval
     {
       public:
-        TriggerByInterval(Real initial_interval);
+        TriggerByInterval(TimeStepper &time_stepper, Real initial_interval);
         bool operator()(BaseDynamics<Real> &interval_evaluator);
         bool operator()();
         Real getInterval() const;
+        Real getIntervalWithScalingRef() const;
         void incrementPresentTime(Real dt);
 
       private:
+        SingleVariable<Real> *sv_physical_time_;
         Real present_time_, interval_;
     };
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -186,3 +186,75 @@ class TestSimulationConfig:
         assert cfg.solver_parameters.fluid_dynamics is not None
         assert cfg.fluid_bodies[0].particle_reserve_factor == pytest.approx(350.0)
         assert cfg.fluid_boundary_conditions[0].type.value == "emitter"
+
+    def test_fluid_material_accepts_maximum_velocity(self):
+        cfg = _make_minimal_fluid_config(
+            fluid_bodies=[
+                {
+                    "name": "WaterBody",
+                    "material": {
+                        "type": "weakly_compressible_fluid",
+                        "density": 1000.0,
+                        "maximum_velocity": 2.0,
+                    },
+                }
+            ]
+        )
+        assert cfg.fluid_bodies[0].material.maximum_velocity == pytest.approx(2.0)
+        assert cfg.fluid_bodies[0].material.sound_speed is None
+
+    def test_characteristic_dimensions_support_new_base_units(self):
+        cfg = _make_minimal_fluid_config(
+            characteristic_dimensions=[
+                {
+                    "value": 1.0,
+                    "name": "Length",
+                    "hint": "geometries.system_domain.upper_bound",
+                },
+                {
+                    "value": 1.0,
+                    "name": "Temperature",
+                    "hint": "geometries.system_domain.upper_bound",
+                },
+                {
+                    "value": 1.0,
+                    "name": "ElectricCurrent",
+                    "hint": "geometries.system_domain.upper_bound",
+                },
+                {
+                    "value": 1.0,
+                    "name": "AmountOfSubstance",
+                    "hint": "geometries.system_domain.upper_bound",
+                },
+                {
+                    "value": 1.0,
+                    "name": "LuminousIntensity",
+                    "hint": "geometries.system_domain.upper_bound",
+                },
+                {
+                    "value": 1.0,
+                    "name": "AngularVelocity",
+                    "hint": "geometries.system_domain.upper_bound",
+                },
+            ]
+        )
+        names = {d.name.value for d in cfg.characteristic_dimensions or []}
+        assert "Temperature" in names
+        assert "ElectricCurrent" in names
+        assert "AmountOfSubstance" in names
+        assert "LuminousIntensity" in names
+        assert "AngularVelocity" in names
+
+    def test_simbody_constraint_requires_restart(self):
+        with pytest.raises(ValidationError, match="simbody body_constraints require solver_parameters.restart"):
+            _make_minimal_fluid_config(
+                body_constraints=[
+                    {
+                        "body_name": "WallBoundary",
+                        "type": "simbody",
+                        "mobilized_body": "planar",
+                        "velocity": [0.0, 0.0],
+                        "angular_velocity": 0.0,
+                    }
+                ]
+            )

--- a/tests/test_simulation/test_2d_simulation/data/dambreak.json
+++ b/tests/test_simulation/test_2d_simulation/data/dambreak.json
@@ -1,7 +1,7 @@
 {
   "characteristic_dimensions": [
     {
-      "value": 10.0,
+      "value": 1.0,
       "name": "Length",
       "hint": "geometries.system_domain.upper_bound"
     },
@@ -77,7 +77,7 @@
       "material": {
         "type": "weakly_compressible_fluid",
         "density": 1.0,
-        "sound_speed": 20.0
+        "maximum_velocity": 2.0
       }
     }
   ],

--- a/tests/test_simulation/test_2d_simulation/data/dambreak.json
+++ b/tests/test_simulation/test_2d_simulation/data/dambreak.json
@@ -1,4 +1,22 @@
 {
+  "characteristic_dimensions": [
+    {
+      "value": 10.0,
+      "name": "Length",
+      "hint": "geometries.system_domain.upper_bound"
+    },
+    {
+      "value": 1.0,
+      "name": "Gravity",
+      "hint": "gravity"
+    },
+    {
+      "value": 1.0,
+      "name": "Density",
+      "hint": "fluid_bodies[name=WaterBody].material.density"
+    }
+  ],
+
   "simulation_type": "fluid_dynamics",
 
   "geometries": {


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the simulation configuration and scaling logic, focusing on improved flexibility for material properties, better unit scaling, and more robust time-stepping and validation. The main themes are: (1) expanded support for physical dimensions and material configuration, (2) improved scaling and unit handling, and (3) enhanced time-stepping with scaling awareness.

**Key changes:**

#### 1. Material Configuration and Validation
* Added new fundamental and derived physical dimensions to `CharacteristicDimensionName` (e.g., `TEMPERATURE`, `ELECTRIC_CURRENT`, `AMOUNT_OF_SUBSTANCE`, `LUMINOUS_INTENSITY`, `ANGULAR_VELOCITY`) to support a broader range of physical properties.
* Updated `MaterialConfig` to support an optional `maximum_velocity` property, and relaxed validation for weakly compressible fluids to accept either `sound_speed` or `maximum_velocity` (with at least one required). [[1]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289R322) [[2]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289L327-R338)
* In the material builder, added logic to compute `sound_speed` from `maximum_velocity` if not directly provided, improving user flexibility in material specification.

#### 2. Scaling and Unit Handling Improvements
* Refactored `ScalingConfig` to add utility methods for checking numeric arrays, resolving JSON paths to either scalars or arrays, and determining if scaling is enabled. The `resolve` method now supports both scalars and floating-point arrays, ensuring robust unit conversion. [[1]](diffhunk://#diff-817002f18c03bcf0e7e7e294c0e5c2e29b12151a36e9d73edeb84581172f8454R15-R48) [[2]](diffhunk://#diff-817002f18c03bcf0e7e7e294c0e5c2e29b12151a36e9d73edeb84581172f8454L82-R115) [[3]](diffhunk://#diff-817002f18c03bcf0e7e7e294c0e5c2e29b12151a36e9d73edeb84581172f8454R208-R212) [[4]](diffhunk://#diff-33e8d005b2e3e1fe8097e3db8fae3b34d502780db88a99a0aa35ffe313a3cdb9R65) [[5]](diffhunk://#diff-33e8d005b2e3e1fe8097e3db8fae3b34d502780db88a99a0aa35ffe313a3cdb9R84-R85)
* Improved error handling and validation in `jsonToVecd` to enforce correct array dimensions and types for vector conversions.

#### 3. Time-Stepping and Output Scaling
* Refactored time-stepping logic to use scaling-aware methods for physical time and time step size, ensuring output is reported in physical units. Added `getPhysicalTimeWithScalingRef`, `getGlobalTimeStepSizeWithScalingRef`, and `getIntervalWithScalingRef` to the `TimeStepper` and its interval triggers. [[1]](diffhunk://#diff-3908014666e46236d854e93af3e904d43da7979cc09358fc9ab5364a9800c02fL9-R9) [[2]](diffhunk://#diff-3908014666e46236d854e93af3e904d43da7979cc09358fc9ab5364a9800c02fL30-R29) [[3]](diffhunk://#diff-3908014666e46236d854e93af3e904d43da7979cc09358fc9ab5364a9800c02fR56-R59) [[4]](diffhunk://#diff-3908014666e46236d854e93af3e904d43da7979cc09358fc9ab5364a9800c02fL100-R102) [[5]](diffhunk://#diff-3908014666e46236d854e93af3e904d43da7979cc09358fc9ab5364a9800c02fR136-R145) [[6]](diffhunk://#diff-c2b210d6d4239415e13fbce76f74ef8eac5beb35211e3992a7de84d73bd79904R47-R48) [[7]](diffhunk://#diff-c2b210d6d4239415e13fbce76f74ef8eac5beb35211e3992a7de84d73bd79904L122-R132)
* Updated simulation builders to use scaling references for velocity and time, and to output time and step sizes in scaled (physical) units during simulation. [[1]](diffhunk://#diff-8ce6fc1ceeaa26af117eb0f0362d5d888ee171f68d695c335e8a7992ff0b7b65R17) [[2]](diffhunk://#diff-8ce6fc1ceeaa26af117eb0f0362d5d888ee171f68d695c335e8a7992ff0b7b65L67-R68) [[3]](diffhunk://#diff-acfdde991811acc801ecb924dc2cba2c734327ee48ac34e39bda7991bc6edd1aL74-R74) [[4]](diffhunk://#diff-acfdde991811acc801ecb924dc2cba2c734327ee48ac34e39bda7991bc6edd1aL93) [[5]](diffhunk://#diff-acfdde991811acc801ecb924dc2cba2c734327ee48ac34e39bda7991bc6edd1aL133-R131) [[6]](diffhunk://#diff-acfdde991811acc801ecb924dc2cba2c734327ee48ac34e39bda7991bc6edd1aL144-R145)

#### 4. Validation Enhancements
* Added validation to ensure that Simbody constraints require a restart section in solver parameters, preventing misconfiguration at runtime.

#### 5. Cleanup
* Removed an unnecessary include of `sph_solver.h` from `all_shared_physical_dynamics_ck.h`.