### PR TITLE
to have ci test

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -30,6 +30,9 @@ Configuration: WaterBody (fluid) + WallBoundary (solid)
 ✓ Config updated and saved to config.json
 ✓ Schema validation passed
 
+> explore what bodies and materials does this simulation support?
+SPHinXsim supports fluid, continuum, and solid body definitions, with schema-validated material types.
+
 > validate
 Configuration: WaterBody (fluid) + WallBoundary (solid)
   Domain: [0, 0] to [5.37, 5.37]
@@ -60,6 +63,7 @@ Inside the shell, you can use the following commands:
 | --- | --- |
 | `generate "description"` | Generate a new config from natural language description |
 | `update "instruction"` | Modify the current config with an instruction (e.g., "change end time to 5 s") |
+| `explore "question"` | Ask the configured LLM questions about the simulator schema and capabilities |
 | `validate` | Display the current config structure and validate it |
 | `run` | Build and execute the validated simulation |
 | `help` | Show available commands |
@@ -114,6 +118,19 @@ This:
 4. Validates the updated config
 5. Saves the result to `config_updated.json`
 
+### Explore
+
+Ask the configured LLM questions about the simulator schema, supported bodies, materials, and workflow behavior:
+
+```bash
+sphinxsim explore "What body types are valid in SimulationConfig?"
+```
+
+This:
+1. Sends your question and schema context to the selected LLM provider
+2. Returns a plain-text explanation of the simulator schema and capabilities
+3. Uses the same provider selection as `generate` and `update`
+
 ### Run
 
 Execute a validated simulation:
@@ -159,6 +176,7 @@ sphinxsim run --config config_v1.json
 sphinxsim shell --config config.json
 > validate
 > update "change particle spacing to 1 cm"
+> explore what materials can I use for solid bodies?
 > validate
 > run
 ```
@@ -211,6 +229,7 @@ sphinxsim generate --description "water dam break"
 ## Output locations
 
 - **Generated configs**: Saved to the path specified by `--output` (default: `config.json`)
+- **Explore answers**: Printed to stdout; no files are written
 - **Simulation output**: Saved to `build-integrated/output/`
 - **Temporary files**: Stored in `.build-temp/`
 
@@ -220,7 +239,8 @@ If config generation or validation fails:
 
 1. **Generation fails**: The LLM response did not match the expected JSON schema. Check the error message for details, or try rephrasing your description.
 2. **Validation fails**: The config violates a schema constraint (e.g., body type mismatch). Use `sphinxsim validate` to see which field is invalid.
-3. **Execution fails**: The config is valid but the simulation failed. Check simulation output in `build-integrated/output/`.
+3. **Explore fails**: The LLM could not answer using the schema context. Rephrase the question to focus on supported bodies, materials, solver settings, or CLI workflow.
+4. **Execution fails**: The config is valid but the simulation failed. Check simulation output in `build-integrated/output/`.
 
 ## See also
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -1,0 +1,228 @@
+# CLI Usage Guide
+
+SPHinXsim provides a command-line interface for building, validating, updating, and running SPH simulations. This guide covers all available commands and workflows.
+
+## Quick start
+
+### Interactive shell mode (recommended)
+
+The easiest way to get started is the interactive shell:
+
+```bash
+sphinxsim shell
+```
+
+This opens an interactive prompt where you can enter commands sequentially:
+
+```
+> generate "water dam break simulation"
+✓ Config generated and saved to config.json
+✓ Schema validation passed
+
+> validate
+Configuration: WaterBody (fluid) + WallBoundary (solid)
+  Domain: [0, 0] to [5.37, 5.37]
+  Resolution: 0.025 m
+  End time: 0.5 s
+  Gravity: [0, -1] m/s²
+
+> update "simulate for 2 s"
+✓ Config updated and saved to config.json
+✓ Schema validation passed
+
+> validate
+Configuration: WaterBody (fluid) + WallBoundary (solid)
+  Domain: [0, 0] to [5.37, 5.37]
+  Resolution: 0.025 m
+  End time: 2.0 s
+  Gravity: [0, -1] m/s²
+
+> run
+Building simulation...
+Running SPH simulation...
+Output saved to: build-integrated/output
+
+> exit
+Goodbye!
+```
+
+### Shell with custom config file
+
+```bash
+sphinxsim shell --config my_simulation.json
+```
+
+### Shell commands
+
+Inside the shell, you can use the following commands:
+
+| Command | Description |
+| --- | --- |
+| `generate "description"` | Generate a new config from natural language description |
+| `update "instruction"` | Modify the current config with an instruction (e.g., "change end time to 5 s") |
+| `validate` | Display the current config structure and validate it |
+| `run` | Build and execute the validated simulation |
+| `help` | Show available commands |
+| `exit` | Quit the shell |
+
+## Direct commands (non-interactive)
+
+You can also run individual commands directly:
+
+### Generate
+
+Create a new simulation config from a natural language description:
+
+```bash
+sphinxsim generate --description "2D water dam break with 0.5 m/s initial velocity" --output config.json
+```
+
+This:
+1. Sends your description to the LLM provider (mock by default, or Ollama if configured)
+2. Receives a JSON config in response
+3. Validates the config against strict schemas
+4. Saves the result to `config.json`
+5. Prints a summary
+
+### Validate
+
+Check an existing config without modifying it:
+
+```bash
+sphinxsim validate --config config.json
+```
+
+This displays:
+- Simulation type (fluid_dynamics, continuum_dynamics, or coupled)
+- List of bodies and their material types
+- Domain bounds and resolution
+- Solver parameters (end time, output interval, etc.)
+- Any validation errors
+
+### Update
+
+Modify an existing config with natural language instructions:
+
+```bash
+sphinxsim update --config config.json --description "increase end time to 10 s" --output config_updated.json
+```
+
+This:
+1. Loads the existing config
+2. Sends it to the LLM provider along with your instruction
+3. Receives a modified JSON config
+4. Validates the updated config
+5. Saves the result to `config_updated.json`
+
+### Run
+
+Execute a validated simulation:
+
+```bash
+sphinxsim run --config config.json
+```
+
+This:
+1. Validates the config
+2. Builds SPHinXsys simulation components in C++
+3. Runs the simulation
+4. Saves output to `build-integrated/output`
+
+## Workflow examples
+
+### Example 1: Quick iteration with the shell
+
+```bash
+sphinxsim shell
+> generate "2D water dam break, domain 5m x 5m, resolution 2.5cm"
+> validate
+> run
+> exit
+```
+
+### Example 2: Compare two configurations
+
+```bash
+sphinxsim generate --description "water dam break" --output config_v1.json
+sphinxsim validate --config config_v1.json
+
+sphinxsim generate --description "water dam break with faster gravity" --output config_v2.json
+sphinxsim validate --config config_v2.json
+
+# Then run the version you prefer:
+sphinxsim run --config config_v1.json
+```
+
+### Example 3: Fine-tune a config without regenerating
+
+```bash
+sphinxsim shell --config config.json
+> validate
+> update "change particle spacing to 1 cm"
+> validate
+> run
+```
+
+### Example 4: Batch process with direct commands
+
+```bash
+for desc in "water dam break" "sloshing tank" "wave propagation"; do
+  sphinxsim generate --description "$desc" --output "config_$desc.json"
+  sphinxsim validate --config "config_$desc.json"
+done
+```
+
+## LLM provider selection
+
+By default, `sphinxsim` uses a local mock LLM that works offline. To use a different provider:
+
+### Use Ollama (local LLM inference)
+
+```bash
+export SPHINXSIM_LLM_PROVIDER=ollama
+export OLLAMA_BASE_URL=http://localhost:11434
+export OLLAMA_MODEL=qwen2.5:3b
+sphinxsim generate --description "water dam break"
+```
+
+First, ensure Ollama is running:
+```bash
+ollama serve
+# In another terminal:
+ollama pull qwen2.5:3b
+```
+
+### Use OpenAI
+
+```bash
+export SPHINXSIM_LLM_PROVIDER=openai
+export OPENAI_API_KEY=sk-...
+export OPENAI_MODEL=gpt-4
+sphinxsim generate --description "water dam break"
+```
+
+### Use mock (default)
+
+```bash
+export SPHINXSIM_LLM_PROVIDER=mock
+sphinxsim generate --description "water dam break"
+```
+
+## Output locations
+
+- **Generated configs**: Saved to the path specified by `--output` (default: `config.json`)
+- **Simulation output**: Saved to `build-integrated/output/`
+- **Temporary files**: Stored in `.build-temp/`
+
+## Error handling
+
+If config generation or validation fails:
+
+1. **Generation fails**: The LLM response did not match the expected JSON schema. Check the error message for details, or try rephrasing your description.
+2. **Validation fails**: The config violates a schema constraint (e.g., body type mismatch). Use `sphinxsim validate` to see which field is invalid.
+3. **Execution fails**: The config is valid but the simulation failed. Check simulation output in `build-integrated/output/`.
+
+## See also
+
+- [LLM Testing](llm-testing.md) for local testing with mock and Ollama
+- [Schema reference](index.md#current-capabilities) for supported simulation types and materials

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,16 +16,29 @@ The project is designed around explicit simulation configuration rather than opa
 
 ## Core workflow
 
-The current user loop is:
+The recommended user workflow is to use the **interactive shell**:
 
-1. Describe a simulation in natural language.
-2. Generate a JSON config with `sphinxsim generate`.
-3. Refine an existing config with `sphinxsim update`.
-4. Validate structure and cross-field consistency with `sphinxsim validate`.
-5. Run the validated case with `sphinxsim run`.
-6. Iterate on geometry, materials, solver settings, and rerun.
+```bash
+sphinxsim shell
+```
 
-This keeps simulation inputs reproducible and reviewable while still allowing fast iteration through LLM assistance.
+Inside the shell, you can:
+
+1. **Generate** a simulation config from natural language: `generate "water dam break"`
+2. **Validate** the config structure: `validate`
+3. **Update** it with further instructions: `update "simulate for 2 s"`
+4. **Run** the validated simulation: `run`
+
+Each command auto-validates and auto-saves, so you always have a working config on disk.
+
+Alternatively, you can use direct commands for non-interactive workflows:
+
+- `sphinxsim generate` — Create a config from description
+- `sphinxsim update` — Modify an existing config
+- `sphinxsim validate` — Check config validity
+- `sphinxsim run` — Execute a validated simulation
+
+For detailed examples and all command options, see [CLI Usage](cli-usage.md).
 
 ## High-level architecture
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,15 @@ The repository remains config-first: natural-language generation is useful for i
 
 The codebase is positioned for richer multi-physics growth while staying strict about validation boundaries. In practice, that means expanding benchmark coverage, continuing to improve continuum and coupled workflows, and strengthening the path from prompt to executable, testable simulation assets.
 
+## LLM test matrix
+
+The repository now supports two LLM testing modes:
+
+- Mocked tests are always safe for CI and run without any external service.
+- Ollama integration tests run locally when Ollama is available and are skipped in CI.
+
+See [LLM testing](llm-testing.md) for the exact test matrix, environment variables, and local commands.
+
 ## Why this project matters
 
 SPHinXsys provides strong performance and physical modeling, but direct setup can be expensive for rapid iteration. SPHinXsim narrows that gap by combining:

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,8 @@ Inside the shell, you can:
 1. **Generate** a simulation config from natural language: `generate "water dam break"`
 2. **Validate** the config structure: `validate`
 3. **Update** it with further instructions: `update "simulate for 2 s"`
-4. **Run** the validated simulation: `run`
+4. **Explore** the simulator schema and capabilities: `explore what body types are supported?`
+5. **Run** the validated simulation: `run`
 
 Each command auto-validates and auto-saves, so you always have a working config on disk.
 
@@ -35,6 +36,7 @@ Alternatively, you can use direct commands for non-interactive workflows:
 
 - `sphinxsim generate` — Create a config from description
 - `sphinxsim update` — Modify an existing config
+- `sphinxsim explore` — Ask schema and functionality questions
 - `sphinxsim validate` — Check config validity
 - `sphinxsim run` — Execute a validated simulation
 
@@ -47,7 +49,7 @@ For detailed examples and all command options, see [CLI Usage](cli-usage.md).
 - `sphinxsim/config/schemas.py`:
   Defines the top-level `SimulationConfig` and the typed config surface for system domains, global resolution, shapes, aligned boxes, particle generation, fluid bodies, continuum bodies, solid bodies, boundary conditions, observers, restart settings, body constraints, and extra state recording.
 - `sphinxsim/llm/`:
-  Provides LLM backends that translate natural-language prompts into schema-compliant configs. The default mock backend supports deterministic local testing, while the OpenAI backend can be enabled with environment variables such as `SPHINXSIM_LLM_PROVIDER`, `OPENAI_API_KEY`, and `OPENAI_MODEL`.
+  Provides LLM backends that translate natural-language prompts into schema-compliant configs and answer schema exploration questions. The default mock backend supports deterministic local testing, while the OpenAI backend can be enabled with environment variables such as `SPHINXSIM_LLM_PROVIDER`, `OPENAI_API_KEY`, and `OPENAI_MODEL`.
 - `sphinxsim/sph_simulation/` and native bindings:
   Build and load SPHinXsys-backed simulation objects from validated JSON, including fluid and continuum-oriented workflows exposed through the Python package.
 
@@ -60,6 +62,7 @@ SPHinXsim currently supports a broader config surface than a basic fluid-only de
 - Solid boundary/body definitions required by the current validation and simulation builders.
 - Config-driven geometry composition using domains, shapes, aligned boxes, transforms, and particle-generation settings.
 - Incremental config editing through the CLI update command instead of regenerating cases from scratch.
+- Schema exploration through the CLI explore command for questions about supported bodies, materials, and simulator behavior.
 
 The repository remains config-first: natural-language generation is useful for initialization and revision, but the validated JSON artifact is the authoritative simulation input.
 

--- a/docs/llm-testing.md
+++ b/docs/llm-testing.md
@@ -25,12 +25,54 @@ CI sets `SPHINXSIM_LLM_PROVIDER=mock` so the workflow never depends on an extern
 To exercise the mock and Ollama paths locally:
 
 ```bash
-source setup-local-env.sh
+# Test with mock LLM (no Ollama needed)
 pytest tests/test_ollama_llm.py -v
+
+# Test with live Ollama (requires Ollama running locally)
 pytest tests/test_ollama_llm_integration.py -v
+
+# Run end-to-end example with both mock and Ollama
 pytest examples/test_nlp_to_simulation.py -v
+
+# Or use the interactive shell with Ollama
+source setup-local-env.sh
+sphinxsim shell
+# Then issue commands like: generate "...", update "...", validate, run
 ```
 
 ## How CI behaves
 
 CI runs the mocked tests everywhere and skips the live Ollama cases automatically. This keeps the pipeline stable while still validating the example workflow and the Ollama adapter logic that does not require a live server.
+
+## Interactive shell with Ollama
+
+For interactive development, use the shell mode with Ollama:
+
+```bash
+source setup-local-env.sh  # Sets SPHINXSIM_LLM_PROVIDER=ollama and other vars
+sphinxsim shell
+```
+
+Inside the shell, you can generate and update configs using the live Ollama backend:
+
+```
+> generate "2D water dam break simulation"
+✓ Config generated and saved to config.json
+✓ Schema validation passed
+
+> validate
+Configuration: WaterBody (fluid) + WallBoundary (solid)
+  Domain: [0, 0] to [5.37, 5.37]
+  Resolution: 0.025 m
+  End time: 0.5 s
+
+> update "increase end time to 2 seconds"
+✓ Config updated and saved to config.json
+✓ Schema validation passed
+
+> run
+Building simulation...
+Running SPH simulation...
+```
+
+See [CLI Usage](cli-usage.md) for full shell command reference.

--- a/docs/llm-testing.md
+++ b/docs/llm-testing.md
@@ -37,7 +37,7 @@ pytest examples/test_nlp_to_simulation.py -v
 # Or use the interactive shell with Ollama
 source setup-local-env.sh
 sphinxsim shell
-# Then issue commands like: generate "...", update "...", validate, run
+# Then issue commands like: generate ..., update ..., explore ..., validate, run
 ```
 
 ## How CI behaves
@@ -70,9 +70,12 @@ Configuration: WaterBody (fluid) + WallBoundary (solid)
 ✓ Config updated and saved to config.json
 ✓ Schema validation passed
 
+> explore what body types are supported?
+Supported body types include fluid bodies, continuum bodies, and rigid solid bodies, depending on the schema fields present.
+
 > run
 Building simulation...
 Running SPH simulation...
 ```
 
-See [CLI Usage](cli-usage.md) for full shell command reference.
+See [CLI Usage](cli-usage.md) for full shell command reference, including `explore`.

--- a/docs/llm-testing.md
+++ b/docs/llm-testing.md
@@ -1,0 +1,36 @@
+# LLM Testing
+
+This project uses two distinct LLM test paths so local development can exercise both a mock backend and a live Ollama backend, while CI stays fully deterministic.
+
+## Test matrix
+
+| Test area | Local | CI |
+| --- | --- | --- |
+| `tests/test_ollama_llm.py` | Mocked only | Mocked only |
+| `tests/test_ollama_llm_integration.py` | Live Ollama when available, otherwise skipped | Skipped |
+| `examples/test_nlp_to_simulation.py` | Mocked case plus live Ollama case when available | Mocked case only, live Ollama skipped |
+
+## Environment variables
+
+Local development typically uses [setup-local-env.sh](../setup-local-env.sh) to set:
+
+- `SPHINXSIM_LLM_PROVIDER=ollama`
+- `OLLAMA_BASE_URL=http://localhost:11434`
+- `OLLAMA_MODEL=qwen2.5:3b`
+
+CI sets `SPHINXSIM_LLM_PROVIDER=mock` so the workflow never depends on an external API or a running Ollama server.
+
+## How to run locally
+
+To exercise the mock and Ollama paths locally:
+
+```bash
+source setup-local-env.sh
+pytest tests/test_ollama_llm.py -v
+pytest tests/test_ollama_llm_integration.py -v
+pytest examples/test_nlp_to_simulation.py -v
+```
+
+## How CI behaves
+
+CI runs the mocked tests everywhere and skips the live Ollama cases automatically. This keeps the pipeline stable while still validating the example workflow and the Ollama adapter logic that does not require a live server.

--- a/examples/test_nlp_to_simulation.py
+++ b/examples/test_nlp_to_simulation.py
@@ -14,6 +14,9 @@ import os
 import importlib.util
 import importlib
 from pathlib import Path
+from urllib import error, request
+
+import pytest
 
 def find_project_root(start: Path | None = None):
     start = start or Path.cwd()
@@ -202,15 +205,44 @@ def main():
         # Restore original directory
         os.chdir(original_dir)
 
-def test_nlp_to_simulation():
+
+def _ollama_reachable() -> bool:
+    base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+    try:
+        with request.urlopen(f"{base_url.rstrip('/')}/api/tags", timeout=3):
+            return True
+    except (error.URLError, OSError):
+        return False
+
+
+def _is_ci_environment() -> bool:
+    return bool(os.getenv("CI") or os.getenv("GITHUB_ACTIONS") or os.getenv("GITLAB_CI"))
+
+
+def _ensure_core_2d_available():
     if importlib.util.find_spec("_sphinxsys_core_2d") is None:
-        import pytest
         pytest.skip("_sphinxsys_core_2d is not available in this environment")
     try:
         importlib.import_module("_sphinxsys_core_2d")
     except ImportError:
-        import pytest
         pytest.skip("_sphinxsys_core_2d cannot be imported in this environment")
+
+
+def test_nlp_to_simulation_mock(monkeypatch):
+    _ensure_core_2d_available()
+    monkeypatch.setenv("SPHINXSIM_LLM_PROVIDER", "mock")
+    assert main()
+
+
+@pytest.mark.integration
+def test_nlp_to_simulation_ollama(monkeypatch):
+    _ensure_core_2d_available()
+    if _is_ci_environment():
+        pytest.skip("Skip live Ollama test in CI; CI validates mock provider only")
+    if not _ollama_reachable():
+        pytest.skip("Ollama server is not reachable")
+
+    monkeypatch.setenv("SPHINXSIM_LLM_PROVIDER", "ollama")
     assert main()
 
 if __name__ == "__main__":

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,9 @@
 site_name: SPHinXsim
 
+nav:
+  - Home: index.md
+  - LLM Testing: llm-testing.md
+
 theme:
   name: material
   favicon: images/logo-16x16.ico

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: SPHinXsim
 
 nav:
   - Home: index.md
+  - CLI Usage: cli-usage.md
   - LLM Testing: llm-testing.md
 
 theme:
@@ -33,4 +34,4 @@ font:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js    
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,4 +33,7 @@ addopts = "-p no:cacheprovider"
 python_files = "test_*.py conftest.py"
 testpaths = ["tests"]
 tmp_path_retention_policy = "none"
+markers = [
+    "integration: integration tests requiring live services (skipped in CI and when services unavailable)",
+]
 

--- a/setup-local-env.sh
+++ b/setup-local-env.sh
@@ -5,7 +5,9 @@
 export PYTHONDONTWRITEBYTECODE=1
 
 # Set LLM provider and API keys for local development
-export SPHINXSIM_LLM_PROVIDER=mock
+export SPHINXSIM_LLM_PROVIDER=ollama
+export OLLAMA_BASE_URL="${OLLAMA_BASE_URL:-http://localhost:11434}"
+export OLLAMA_MODEL="${OLLAMA_MODEL:-qwen2.5:3b}"
 
 # Set VCPKG_ROOT for local development
 export VCPKG_ROOT="$HOME/vcpkg"

--- a/sphinxsim/cli.py
+++ b/sphinxsim/cli.py
@@ -40,6 +40,7 @@ original_dir = os.getcwd()
 # NOW import everything else
 import argparse
 import json
+import shlex
 from pathlib import Path
 from typing import Tuple
 
@@ -239,7 +240,7 @@ def cmd_run(args: argparse.Namespace) -> int:
 
     try:
         sim = sph.SPHSimulation(validated_config_path)
-        
+
         # Create temp directory in project root, not relative to cwd
         output_dir = PROJECT_ROOT / ".build-temp" / "test_simulation"
         output_dir.mkdir(exist_ok=True, parents=True)
@@ -250,12 +251,12 @@ def cmd_run(args: argparse.Namespace) -> int:
         print("✅ Simulation configuration loaded")
 
         sim.initializeSimulation()
-        print("✅ Simulation initialized")        
+        print("✅ Simulation initialized")
 
         # Run simulation
         print("\n🚀 Running simulation...")
         sim.run()
-        
+
         print("✅ Simulation completed successfully!")
         print(f"\n📊 Run summary:")
         configured_end_time = config.solver_parameters.end_time
@@ -269,13 +270,13 @@ def cmd_run(args: argparse.Namespace) -> int:
         else:
             first_body_name = "simulation"
         print(f"   Run config: {config_path}")
-        
+
         # Show output location
         safe_name = first_body_name.replace(' ', '_').replace('/', '_')[:50]
         output_dir = PROJECT_ROOT / ".build-temp" / "simulations" / safe_name
         print(f"\n📁 Simulation output saved to:")
         print(f"   {output_dir}")
-        
+
         return 0
 
     except RuntimeError as e:
@@ -308,6 +309,119 @@ def cmd_run(args: argparse.Namespace) -> int:
         except OSError:
             pass
         os.chdir(original_dir)
+
+
+def _shell_resolve_config_path(config_file: str) -> Path:
+    path = Path(config_file)
+    if not path.is_absolute():
+        path = PROJECT_ROOT / ".build-temp" / path
+    return path
+
+
+def _shell_auto_validate(config_path: Path) -> bool:
+    cfg, rc = _load_config(config_path)
+    if rc != 0 or cfg is None:
+        print("❌ Auto-validation failed", file=sys.stderr)
+        return False
+    print(f"✅ Auto-validation passed: {config_path}")
+    return True
+
+
+def cmd_shell(args: argparse.Namespace) -> int:
+    """Interactive shell for generate/update/validate/run workflow."""
+    config_path = _shell_resolve_config_path(args.config_file)
+    print("SPHinXsim interactive shell")
+    print(f"Config file: {config_path}")
+    print("Type: generate \"...\", update \"...\", validate, run, exit")
+
+    while True:
+        try:
+            line = input("sphinxsim> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+
+        if not line:
+            continue
+
+        if line in {"exit", "quit"}:
+            return 0
+
+        if line == "help":
+            print("Commands:")
+            print("  generate \"DESCRIPTION\"")
+            print("  update \"INSTRUCTION\"")
+            print("  validate")
+            print("  run")
+            print("  exit")
+            continue
+
+        try:
+            parts = shlex.split(line)
+        except ValueError as exc:
+            print(f"Invalid command syntax: {exc}", file=sys.stderr)
+            continue
+
+        if not parts:
+            continue
+
+        cmd = parts[0]
+
+        if cmd == "generate":
+            description = " ".join(parts[1:]).strip()
+            if not description:
+                print("Usage: generate \"DESCRIPTION\"", file=sys.stderr)
+                continue
+            llm = get_llm()
+            try:
+                config = llm.generate(description)
+                config_path.parent.mkdir(parents=True, exist_ok=True)
+                config_path.write_text(config.model_dump_json(indent=2, exclude_none=True))
+                print(f"Config written to {config_path}")
+                _shell_auto_validate(config_path)
+            except (ValueError, ValidationError) as exc:
+                print(f"Error generating config: {exc}", file=sys.stderr)
+            except OSError as exc:
+                print(f"Error writing config to {config_path}: {exc}", file=sys.stderr)
+            continue
+
+        if cmd == "update":
+            instruction = " ".join(parts[1:]).strip()
+            if not instruction:
+                print("Usage: update \"INSTRUCTION\"", file=sys.stderr)
+                continue
+            current, rc = _load_config(config_path)
+            if rc != 0 or current is None:
+                print("No valid config found. Run generate first.", file=sys.stderr)
+                continue
+            llm = get_llm()
+            if not hasattr(llm, "update"):
+                print(
+                    "The selected LLM provider does not support config updates.",
+                    file=sys.stderr,
+                )
+                continue
+            try:
+                updated = llm.update(current, instruction)
+                config_path.parent.mkdir(parents=True, exist_ok=True)
+                config_path.write_text(updated.model_dump_json(indent=2, exclude_none=True))
+                print(f"Updated config written to {config_path}")
+                _shell_auto_validate(config_path)
+            except (ValueError, ValidationError) as exc:
+                print(f"Error updating config: {exc}", file=sys.stderr)
+            except OSError as exc:
+                print(f"Error writing config to {config_path}: {exc}", file=sys.stderr)
+            continue
+
+        if cmd == "validate":
+            _ = cmd_validate(argparse.Namespace(config_file=str(config_path)))
+            continue
+
+        if cmd == "run":
+            _ = cmd_run(argparse.Namespace(config_file=str(config_path)))
+            continue
+
+        print(f"Unknown command: {cmd}. Type 'help' for commands.", file=sys.stderr)
 
 # ---------------------------------------------------------------------------
 # Argument parser
@@ -361,6 +475,19 @@ def _build_parser() -> argparse.ArgumentParser:
     run = subparsers.add_parser("run", help="Run a simulation from a JSON config file.")
     run.add_argument("config_file", nargs='?', default="config.json", help="Path to JSON config file.")
     run.set_defaults(func=cmd_run)
+
+    # shell
+    shell = subparsers.add_parser(
+        "shell",
+        help="Interactive command loop with auto-save and auto-validate.",
+    )
+    shell.add_argument(
+        "--config",
+        dest="config_file",
+        default="config.json",
+        help="Config file used by interactive commands (default: config.json).",
+    )
+    shell.set_defaults(func=cmd_shell)
 
     return parser
 

--- a/sphinxsim/cli.py
+++ b/sphinxsim/cli.py
@@ -311,6 +311,49 @@ def cmd_run(args: argparse.Namespace) -> int:
         os.chdir(original_dir)
 
 
+def _schema_explore_context() -> str:
+    schema = json.dumps(SimulationConfig.model_json_schema(), indent=2)
+    return (
+        "You are helping a user understand the SPHinXsim simulator schema and capabilities. "
+        "Answer clearly and concisely using the schema as the source of truth. "
+        "When relevant, include practical command examples.\n\n"
+        "CLI capabilities:\n"
+        "- generate: create a config from natural language\n"
+        "- update: revise an existing config with natural language\n"
+        "- validate: schema-validate and summarize a config\n"
+        "- run: execute simulation from validated config\n"
+        "- shell: interactive mode for generate/update/validate/run\n\n"
+        "SimulationConfig JSON schema:\n"
+        f"{schema}"
+    )
+
+
+def cmd_explore(args: argparse.Namespace) -> int:
+    """Answer schema/functionality questions using the configured LLM provider."""
+    question = args.question.strip() if args.question else ""
+    if not question:
+        print("question must not be empty", file=sys.stderr)
+        return 1
+
+    llm = get_llm()
+    if not hasattr(llm, "explore"):
+        print(
+            "The selected LLM provider does not support schema exploration.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        answer = llm.explore(question, context=_schema_explore_context())
+    except Exception as exc:
+        print(f"Error exploring schema: {exc}", file=sys.stderr)
+        return 1
+
+    print("Top-level SimulationConfig fields and guidance:")
+    print(answer)
+    return 0
+
+
 def _shell_resolve_config_path(config_file: str) -> Path:
     path = Path(config_file)
     if not path.is_absolute():
@@ -332,7 +375,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
     config_path = _shell_resolve_config_path(args.config_file)
     print("SPHinXsim interactive shell")
     print(f"Config file: {config_path}")
-    print("Type: generate \"...\", update \"...\", validate, run, exit")
+    print("Type: generate ..., update ..., explore ..., validate, run, exit")
 
     while True:
         try:
@@ -349,8 +392,9 @@ def cmd_shell(args: argparse.Namespace) -> int:
 
         if line == "help":
             print("Commands:")
-            print("  generate \"DESCRIPTION\"")
-            print("  update \"INSTRUCTION\"")
+            print("  generate DESCRIPTION")
+            print("  update INSTRUCTION")
+            print("  explore QUESTION")
             print("  validate")
             print("  run")
             print("  exit")
@@ -370,7 +414,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
         if cmd == "generate":
             description = " ".join(parts[1:]).strip()
             if not description:
-                print("Usage: generate \"DESCRIPTION\"", file=sys.stderr)
+                print("Usage: generate DESCRIPTION", file=sys.stderr)
                 continue
             llm = get_llm()
             try:
@@ -388,7 +432,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
         if cmd == "update":
             instruction = " ".join(parts[1:]).strip()
             if not instruction:
-                print("Usage: update \"INSTRUCTION\"", file=sys.stderr)
+                print("Usage: update INSTRUCTION", file=sys.stderr)
                 continue
             current, rc = _load_config(config_path)
             if rc != 0 or current is None:
@@ -411,6 +455,14 @@ def cmd_shell(args: argparse.Namespace) -> int:
                 print(f"Error updating config: {exc}", file=sys.stderr)
             except OSError as exc:
                 print(f"Error writing config to {config_path}: {exc}", file=sys.stderr)
+            continue
+
+        if cmd == "explore":
+            question = " ".join(parts[1:]).strip()
+            if not question:
+                print("Usage: explore QUESTION", file=sys.stderr)
+                continue
+            _ = cmd_explore(argparse.Namespace(question=question))
             continue
 
         if cmd == "validate":
@@ -475,6 +527,14 @@ def _build_parser() -> argparse.ArgumentParser:
     run = subparsers.add_parser("run", help="Run a simulation from a JSON config file.")
     run.add_argument("config_file", nargs='?', default="config.json", help="Path to JSON config file.")
     run.set_defaults(func=cmd_run)
+
+    # explore
+    exp = subparsers.add_parser(
+        "explore",
+        help="Ask schema/functionality questions using the configured LLM provider.",
+    )
+    exp.add_argument("question", help="Question about the simulator schema or functionality.")
+    exp.set_defaults(func=cmd_explore)
 
     # shell
     shell = subparsers.add_parser(

--- a/sphinxsim/cli.py
+++ b/sphinxsim/cli.py
@@ -373,8 +373,12 @@ def _shell_auto_validate(config_path: Path) -> bool:
 def cmd_shell(args: argparse.Namespace) -> int:
     """Interactive shell for generate/update/validate/run workflow."""
     config_path = _shell_resolve_config_path(args.config_file)
+    provider = os.getenv("SPHINXSIM_LLM_PROVIDER", "mock")
     print("SPHinXsim interactive shell")
+    print(f"LLM provider: {provider}")
     print(f"Config file: {config_path}")
+    if not Path(args.config_file).is_absolute():
+        print("Note: relative config paths are resolved under .build-temp/")
     print("Type: generate ..., update ..., explore ..., validate, run, exit")
 
     while True:

--- a/sphinxsim/config/schemas.py
+++ b/sphinxsim/config/schemas.py
@@ -241,6 +241,34 @@ class GeometriesConfig(BaseModel):
     shapes: List[ShapeConfig] = Field(..., min_length=1)
     aligned_boxes: List[AlignedBoxConfig] = Field(default_factory=list)
 
+    @model_validator(mode="after")
+    def _validate_shape_references(self) -> "GeometriesConfig":
+        """Ensure shape definitions are unique and only reference earlier shapes."""
+        defined_shape_names: set[str] = set()
+
+        for shape in self.shapes:
+            if shape.name in defined_shape_names:
+                raise ValueError(
+                    f"geometries.shapes contains duplicate shape name '{shape.name}'"
+                )
+
+            if shape.type == BodyShapeType.EXPANDED_BOX:
+                if shape.original not in defined_shape_names:
+                    raise ValueError(
+                        f"expanded_box shape '{shape.name}' must reference a previously defined shape in original"
+                    )
+
+            if shape.type == BodyShapeType.COMPLEX_SHAPE:
+                for sub_shape in shape.sub_shapes or []:
+                    if sub_shape not in defined_shape_names:
+                        raise ValueError(
+                            f"complex_shape '{shape.name}' has sub_shape '{sub_shape}' that is not previously defined"
+                        )
+
+            defined_shape_names.add(shape.name)
+
+        return self
+
 
 class RelaxationBodyConfig(BaseModel):
     level_set: Optional[dict] = None

--- a/sphinxsim/llm/__init__.py
+++ b/sphinxsim/llm/__init__.py
@@ -24,6 +24,7 @@ def get_llm():
         return OllamaLLM(
             base_url=os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
             model=os.getenv("OLLAMA_MODEL", "qwen2.5:3b"),
+            timeout=float(os.getenv("OLLAMA_TIMEOUT", "180")),
         )
         
     from sphinxsim.llm.mock_llm import MockLLM

--- a/sphinxsim/llm/__init__.py
+++ b/sphinxsim/llm/__init__.py
@@ -1,9 +1,16 @@
 """sphinxsim.llm – LLM helpers (mock and production)."""
 
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sphinxsim.llm.mock_llm import MockLLM
+    from sphinxsim.llm.ollama_llm import OllamaLLM
+    from sphinxsim.llm.openai_llm import OpenAILLM
 
 def get_llm():
     provider = os.getenv("SPHINXSIM_LLM_PROVIDER", "mock")
+
     if provider == "openai":
         from sphinxsim.llm.openai_llm import OpenAILLM
 
@@ -11,11 +18,19 @@ def get_llm():
             model=os.getenv("OPENAI_MODEL", "gpt-4.1-mini"),
             api_key=os.getenv("OPENAI_API_KEY"),
         )
+    
+    if provider == "ollama":
+        from sphinxsim.llm.ollama_llm import OllamaLLM
+        return OllamaLLM(
+            base_url=os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
+            model=os.getenv("OLLAMA_MODEL", "qwen2.5:3b"),
+        )
+        
     from sphinxsim.llm.mock_llm import MockLLM
 
     return MockLLM()
 
-__all__ = ["MockLLM", "OpenAILLM", "get_llm"]
+__all__ = ["MockLLM", "OpenAILLM", "OllamaLLM", "get_llm"]
 
 
 def __getattr__(name):
@@ -23,8 +38,16 @@ def __getattr__(name):
         from sphinxsim.llm.mock_llm import MockLLM
 
         return MockLLM
+    
     if name == "OpenAILLM":
         from sphinxsim.llm.openai_llm import OpenAILLM
 
         return OpenAILLM
+    
+    if name == "OllamaLLM":
+        from sphinxsim.llm.ollama_llm import OllamaLLM
+
+        return OllamaLLM
+
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/sphinxsim/llm/mock_llm.py
+++ b/sphinxsim/llm/mock_llm.py
@@ -8,6 +8,8 @@ deterministic, schema-validated configs without any network access.
 from __future__ import annotations
 
 import re
+import json
+from pathlib import Path
 from typing import Any, Dict, List
 
 from sphinxsim.config.schemas import (
@@ -409,6 +411,26 @@ def _apply_updates(existing: Dict[str, Any], description: str) -> Dict[str, Any]
     return cfg
 
 
+def _fixture_template_for_physics(physics: PhysicsType) -> Dict[str, Any] | None:
+    """Load a validated fixture template for the given physics type when available."""
+    root = Path(__file__).resolve().parents[2]
+    fixture_rel = {
+        PhysicsType.FLUID: Path("tests/test_simulation/test_2d_simulation/data/dambreak.json"),
+        PhysicsType.SOLID: Path("tests/test_simulation/test_2d_simulation/data/milling.json"),
+    }.get(physics)
+
+    if fixture_rel is None:
+        return None
+
+    fixture_path = root / fixture_rel
+    try:
+        payload = json.loads(fixture_path.read_text())
+        validated = SimulationConfig.model_validate(payload)
+        return validated.model_dump(exclude_none=True)
+    except Exception:
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -451,7 +473,8 @@ class MockLLM:
             raise ValueError("description must not be empty")
 
         physics = _detect_physics(description)
-        template = _apply_overrides(_TEMPLATES[physics], description)
+        base_template = _fixture_template_for_physics(physics) or _TEMPLATES[physics]
+        template = _apply_overrides(base_template, description)
 
         return SimulationConfig(**template)
 

--- a/sphinxsim/llm/mock_llm.py
+++ b/sphinxsim/llm/mock_llm.py
@@ -462,3 +462,16 @@ class MockLLM:
 
         updated = _apply_updates(existing.model_dump(), description)
         return SimulationConfig(**updated)
+
+    def explore(self, question: str, context: str | None = None) -> str:
+        """Return a deterministic schema/functionality explanation for local usage."""
+        if not question or not question.strip():
+            raise ValueError("question must not be empty")
+
+        top_level_fields = sorted(SimulationConfig.model_json_schema().get("properties", {}).keys())
+        return (
+            "Mock exploration mode (deterministic). "
+            "SPHinXsim supports generate, update, validate, run, and shell workflows. "
+            f"Top-level SimulationConfig fields: {', '.join(top_level_fields)}. "
+            f"Question received: {question.strip()}"
+        )

--- a/sphinxsim/llm/mock_llm.py
+++ b/sphinxsim/llm/mock_llm.py
@@ -452,17 +452,6 @@ class MockLLM:
 
         physics = _detect_physics(description)
         template = _apply_overrides(_TEMPLATES[physics], description)
-        if template.get("fluid_bodies"):
-            template["fluid_bodies"][0]["name"] = _extract_name(description)
-            template["geometries"]["shapes"][0]["name"] = template["fluid_bodies"][0]["name"]
-            if template.get("observers"):
-                template["observers"][0]["observed_body"] = template["fluid_bodies"][0]["name"]
-
-            # Keep particle-generation body list in sync with body name.
-            settings = template.get("particle_generation", {}).get("settings", {})
-            for body in settings.get("bodies", []):
-                if body.get("name") == "WaterBody":
-                    body["name"] = template["fluid_bodies"][0]["name"]
 
         return SimulationConfig(**template)
 

--- a/sphinxsim/llm/ollama_llm.py
+++ b/sphinxsim/llm/ollama_llm.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import re
+from difflib import get_close_matches
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict
 from urllib import error, request
 
@@ -71,7 +73,42 @@ class OllamaLLM:
 
     @staticmethod
     def _example_config(description: str) -> Dict[str, Any]:
-        """Return a physics-matched canonical example config for few-shot prompting."""
+        """Return a validated fixture-backed example config for few-shot prompting."""
+        project_root = Path(__file__).resolve().parents[2]
+        fluid_fixture = (
+            project_root
+            / "tests"
+            / "test_simulation"
+            / "test_2d_simulation"
+            / "data"
+            / "dambreak.json"
+        )
+        solid_fixture = (
+            project_root
+            / "tests"
+            / "test_simulation"
+            / "test_2d_simulation"
+            / "data"
+            / "milling.json"
+        )
+
+        desc = (description or "").lower()
+        is_solid_like = any(
+            token in desc for token in ("solid", "elastic", "beam", "continuum", "milling")
+        )
+
+        preferred = solid_fixture if is_solid_like else fluid_fixture
+        fallback = fluid_fixture if preferred == solid_fixture else solid_fixture
+
+        for fixture in (preferred, fallback):
+            try:
+                payload = json.loads(fixture.read_text())
+                validated = SimulationConfig.model_validate(payload)
+                return json.loads(validated.model_dump_json(exclude_none=True))
+            except Exception:
+                continue
+
+        # Last resort if fixture files are unavailable/corrupt.
         from sphinxsim.llm.mock_llm import MockLLM
 
         return json.loads(MockLLM().generate(description).model_dump_json(exclude_none=True))
@@ -120,6 +157,134 @@ class OllamaLLM:
     @staticmethod
     def _sanitize_config_dict(cfg: Dict[str, Any]) -> Dict[str, Any]:
         updated = json.loads(json.dumps(cfg))
+
+        # Keep generated/output configs robust for runtime by omitting optional
+        # scaling hints that small models frequently corrupt.
+        updated.pop("characteristic_dimensions", None)
+
+        shapes = updated.get("geometries", {}).get("shapes", [])
+        shape_names = {
+            shape.get("name")
+            for shape in shapes
+            if isinstance(shape, dict) and shape.get("name")
+        }
+
+        rename_map: Dict[str, str] = {}
+        shape_rename_map: Dict[str, str] = {}
+
+        def _canonical_name(name: str | None) -> str | None:
+            if not name:
+                return name
+            if name in shape_names:
+                return name
+            candidates = get_close_matches(name, list(shape_names), n=1, cutoff=0.6)
+            if candidates:
+                return candidates[0]
+            return name
+
+        # Build a map of potential typos in shape names themselves
+        # by looking for common misspellings (e.g., Wal* → Wall*)
+        for shape in shapes:
+            if not isinstance(shape, dict):
+                continue
+            name = shape.get("name")
+            if name and "Wal" in name and name not in shape_names:
+                # Potential typo like WalInnerBox → WallInnerBox
+                corrected = name.replace("Wal", "Wall")
+                if corrected in shape_names:
+                    shape_rename_map[name] = corrected
+                    shape["name"] = corrected
+                    # Update shape_names set to reflect the rename
+                    shape_names.discard(name)
+                    shape_names.add(corrected)
+
+        # Second pass: fix shape references that point to typoed names.
+        for shape in shapes:
+            if not isinstance(shape, dict):
+                continue
+            original = shape.get("original")
+            if isinstance(original, str):
+                original = shape_rename_map.get(original, original)
+                shape["original"] = _canonical_name(original)
+            sub_shapes = shape.get("sub_shapes")
+            if isinstance(sub_shapes, list):
+                shape["sub_shapes"] = [
+                    _canonical_name(shape_rename_map.get(item, item) if isinstance(item, str) else item)
+                    if isinstance(item, str)
+                    else item
+                    for item in sub_shapes
+                ]
+
+        for body in updated.get("fluid_bodies", []):
+            if not isinstance(body, dict):
+                continue
+            old = body.get("name")
+            new = _canonical_name(old)
+            if old and new and old != new:
+                rename_map[old] = new
+                body["name"] = new
+
+        for body in updated.get("solid_bodies", []):
+            if not isinstance(body, dict):
+                continue
+            old = body.get("name")
+            new = _canonical_name(old)
+            if old and new and old != new:
+                rename_map[old] = new
+                body["name"] = new
+
+        # Also canonicalize body names in extra_state_recording to catch typos from LLM output
+        all_body_names = {
+            body.get("name")
+            for bodies_list in [
+                updated.get("fluid_bodies", []),
+                updated.get("solid_bodies", []),
+                updated.get("continuum_bodies", []),
+            ]
+            for body in bodies_list
+            if isinstance(body, dict) and body.get("name")
+        }
+
+        for entry in updated.get("extra_state_recording", []):
+            if not isinstance(entry, dict):
+                continue
+            old_name = entry.get("name")
+            if old_name and old_name not in all_body_names:
+                candidates = get_close_matches(old_name, list(all_body_names), n=1, cutoff=0.6)
+                if candidates:
+                    rename_map[old_name] = candidates[0]
+
+        for entry in updated.get("particle_generation", {}).get("settings", {}).get("bodies", []):
+            if isinstance(entry, dict) and entry.get("name") in rename_map:
+                entry["name"] = rename_map[entry["name"]]
+
+        for entry in updated.get("observers", []):
+            if isinstance(entry, dict) and entry.get("observed_body") in rename_map:
+                entry["observed_body"] = rename_map[entry["observed_body"]]
+
+        for entry in updated.get("fluid_boundary_conditions", []):
+            if isinstance(entry, dict) and entry.get("body_name") in rename_map:
+                entry["body_name"] = rename_map[entry["body_name"]]
+
+        for entry in updated.get("body_constraints", []):
+            if isinstance(entry, dict) and entry.get("body_name") in rename_map:
+                entry["body_name"] = rename_map[entry["body_name"]]
+
+        for entry in updated.get("extra_state_recording", []):
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("name") in rename_map:
+                entry["name"] = rename_map[entry["name"]]
+            for variable in entry.get("variables", []):
+                if not isinstance(variable, dict):
+                    continue
+                real_type = variable.get("real_type")
+                vector_type = variable.get("vector_type")
+                if isinstance(real_type, str):
+                    variable["real_type"] = [real_type]
+                if isinstance(vector_type, str):
+                    variable["vector_type"] = [vector_type]
+
         settings = updated.get("particle_generation", {}).get("settings", {})
         bodies = settings.get("bodies", [])
         fluid_names = {body.get("name") for body in updated.get("fluid_bodies", [])}

--- a/sphinxsim/llm/ollama_llm.py
+++ b/sphinxsim/llm/ollama_llm.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import time
 from difflib import get_close_matches
 from dataclasses import dataclass
 from pathlib import Path
@@ -41,14 +42,32 @@ class OllamaLLM:
             method="POST",
         )
 
-        try:
-            with request.urlopen(req, timeout=self.timeout) as resp:
-                raw = resp.read().decode("utf-8")
-        except error.URLError as exc:
-            raise RuntimeError(
-                "Failed to contact Ollama server. "
-                "Ensure Ollama is running and OLLAMA_BASE_URL is correct."
-            ) from exc
+        raw = ""
+        for attempt in range(2):
+            try:
+                with request.urlopen(req, timeout=self.timeout) as resp:
+                    raw = resp.read().decode("utf-8")
+                break
+            except error.URLError as exc:
+                raise RuntimeError(
+                    "Failed to contact Ollama server. "
+                    "Ensure Ollama is running and OLLAMA_BASE_URL is correct."
+                ) from exc
+            except TimeoutError as exc:
+                if attempt == 0:
+                    time.sleep(1)
+                    continue
+                raise RuntimeError(
+                    "Ollama request timed out. Increase OLLAMA_TIMEOUT or use a smaller model."
+                ) from exc
+            except OSError as exc:
+                # socket.py can raise raw TimeoutError/OSError on read timeout
+                if "timed out" in str(exc).lower() and attempt == 0:
+                    time.sleep(1)
+                    continue
+                raise RuntimeError(
+                    "Failed during Ollama request. Ensure Ollama is reachable and responsive."
+                ) from exc
 
         data = json.loads(raw)
         message = data.get("message") or {}
@@ -172,12 +191,21 @@ class OllamaLLM:
         rename_map: Dict[str, str] = {}
         shape_rename_map: Dict[str, str] = {}
 
+        def _normalize_wall_typo(name: str | None) -> str | None:
+            if not name or not isinstance(name, str):
+                return name
+            if name.startswith("Wal") and not name.startswith("Wall"):
+                return "Wall" + name[3:]
+            return name
+
         def _canonical_name(name: str | None) -> str | None:
+            name = _normalize_wall_typo(name)
             if not name:
                 return name
             if name in shape_names:
                 return name
-            candidates = get_close_matches(name, list(shape_names), n=1, cutoff=0.6)
+            shape_candidates = [n for n in shape_names if isinstance(n, str)]
+            candidates = get_close_matches(name, shape_candidates, n=1, cutoff=0.6)
             if candidates:
                 return candidates[0]
             return name
@@ -188,15 +216,12 @@ class OllamaLLM:
             if not isinstance(shape, dict):
                 continue
             name = shape.get("name")
-            if name and "Wal" in name and name not in shape_names:
-                # Potential typo like WalInnerBox → WallInnerBox
-                corrected = name.replace("Wal", "Wall")
-                if corrected in shape_names:
-                    shape_rename_map[name] = corrected
-                    shape["name"] = corrected
-                    # Update shape_names set to reflect the rename
-                    shape_names.discard(name)
-                    shape_names.add(corrected)
+            corrected = _canonical_name(name)
+            if name and corrected and corrected != name:
+                shape_rename_map[name] = corrected
+                shape["name"] = corrected
+                shape_names.discard(name)
+                shape_names.add(corrected)
 
         # Second pass: fix shape references that point to typoed names.
         for shape in shapes:
@@ -219,7 +244,7 @@ class OllamaLLM:
             if not isinstance(body, dict):
                 continue
             old = body.get("name")
-            new = _canonical_name(old)
+            new = _normalize_wall_typo(old)
             if old and new and old != new:
                 rename_map[old] = new
                 body["name"] = new
@@ -228,7 +253,16 @@ class OllamaLLM:
             if not isinstance(body, dict):
                 continue
             old = body.get("name")
-            new = _canonical_name(old)
+            new = _normalize_wall_typo(old)
+            if old and new and old != new:
+                rename_map[old] = new
+                body["name"] = new
+
+        for body in updated.get("continuum_bodies", []):
+            if not isinstance(body, dict):
+                continue
+            old = body.get("name")
+            new = _normalize_wall_typo(old)
             if old and new and old != new:
                 rename_map[old] = new
                 body["name"] = new
@@ -245,36 +279,46 @@ class OllamaLLM:
             if isinstance(body, dict) and body.get("name")
         }
 
+        def _canonical_body_name(name: str | None) -> str | None:
+            name = _normalize_wall_typo(name)
+            if not name:
+                return name
+            if name in all_body_names:
+                return name
+            body_candidates = [n for n in all_body_names if isinstance(n, str)]
+            candidates = get_close_matches(name, body_candidates, n=1, cutoff=0.6)
+            if candidates:
+                return candidates[0]
+            return name
+
         for entry in updated.get("extra_state_recording", []):
             if not isinstance(entry, dict):
                 continue
             old_name = entry.get("name")
-            if old_name and old_name not in all_body_names:
-                candidates = get_close_matches(old_name, list(all_body_names), n=1, cutoff=0.6)
-                if candidates:
-                    rename_map[old_name] = candidates[0]
+            new_name = _canonical_body_name(old_name)
+            if old_name and new_name and old_name != new_name:
+                rename_map[old_name] = new_name
 
         for entry in updated.get("particle_generation", {}).get("settings", {}).get("bodies", []):
-            if isinstance(entry, dict) and entry.get("name") in rename_map:
-                entry["name"] = rename_map[entry["name"]]
+            if isinstance(entry, dict):
+                entry["name"] = _canonical_body_name(entry.get("name"))
 
         for entry in updated.get("observers", []):
-            if isinstance(entry, dict) and entry.get("observed_body") in rename_map:
-                entry["observed_body"] = rename_map[entry["observed_body"]]
+            if isinstance(entry, dict):
+                entry["observed_body"] = _canonical_body_name(entry.get("observed_body"))
 
         for entry in updated.get("fluid_boundary_conditions", []):
-            if isinstance(entry, dict) and entry.get("body_name") in rename_map:
-                entry["body_name"] = rename_map[entry["body_name"]]
+            if isinstance(entry, dict):
+                entry["body_name"] = _canonical_body_name(entry.get("body_name"))
 
         for entry in updated.get("body_constraints", []):
-            if isinstance(entry, dict) and entry.get("body_name") in rename_map:
-                entry["body_name"] = rename_map[entry["body_name"]]
+            if isinstance(entry, dict):
+                entry["body_name"] = _canonical_body_name(entry.get("body_name"))
 
         for entry in updated.get("extra_state_recording", []):
             if not isinstance(entry, dict):
                 continue
-            if entry.get("name") in rename_map:
-                entry["name"] = rename_map[entry["name"]]
+            entry["name"] = _canonical_body_name(entry.get("name"))
             for variable in entry.get("variables", []):
                 if not isinstance(variable, dict):
                     continue
@@ -321,9 +365,10 @@ class OllamaLLM:
             "with values adapted for the new description. "
             "Choose the correct simulation type and body/material families for the requested physics. "
         ) + self._BODY_TYPE_RULES
+        example_cfg = self._example_config(description)
         user = {
             "description": description,
-            "example_output": self._example_config(description),
+            "example_output": example_cfg,
         }
 
         messages = [
@@ -333,9 +378,16 @@ class OllamaLLM:
         data = self._post_chat(messages=messages)
         if not isinstance(data, dict):
             raise ValueError("Ollama returned an invalid generation response")
-        merged = self._merge_dicts(self._example_config(description), data)
+        merged = self._merge_dicts(example_cfg, data)
         merged = self._sanitize_config_dict(merged)
-        return SimulationConfig(**merged)
+        try:
+            return SimulationConfig(**merged)
+        except Exception:
+            # If the model corrupts required structures (e.g. domain bounds),
+            # rehydrate from validated example config while preserving valid edits.
+            repaired = self._merge_dicts(merged, example_cfg)
+            repaired = self._sanitize_config_dict(repaired)
+            return SimulationConfig(**repaired)
 
     def update(self, existing: SimulationConfig, description: str) -> SimulationConfig:
         if not description or not description.strip():
@@ -381,7 +433,12 @@ class OllamaLLM:
                 merged = self._merge_dicts(existing_dict, patch_data)
         merged = self._apply_explicit_instruction_overrides(merged, description)
         merged = self._sanitize_config_dict(merged)
-        return SimulationConfig(**merged)
+        try:
+            return SimulationConfig(**merged)
+        except Exception:
+            repaired = self._merge_dicts(merged, existing_dict)
+            repaired = self._sanitize_config_dict(repaired)
+            return SimulationConfig(**repaired)
 
     def explore(self, question: str, context: str | None = None) -> str:
         if not question or not question.strip():

--- a/sphinxsim/llm/ollama_llm.py
+++ b/sphinxsim/llm/ollama_llm.py
@@ -1,0 +1,121 @@
+"""Ollama-backed LLM provider for SPHinXsim config generation."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict
+from urllib import error, request
+
+from sphinxsim.config.schemas import SimulationConfig
+
+
+@dataclass
+class OllamaLLM:
+    """Generate and update SimulationConfig using a local Ollama server."""
+
+    base_url: str = "http://localhost:11434"
+    model: str = "qwen2.5:3b"
+    timeout: float = 60.0
+
+    def _endpoint(self) -> str:
+        return f"{self.base_url.rstrip('/')}/api/chat"
+
+    def _post_chat(self, *, messages: list) -> Dict[str, Any]:
+        payload = {
+            "model": self.model,
+            "stream": False,
+            # Ask Ollama to return a JSON object in message.content.
+            "format": "json",
+            "messages": messages,
+        }
+
+        body = json.dumps(payload).encode("utf-8")
+        req = request.Request(
+            self._endpoint(),
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        try:
+            with request.urlopen(req, timeout=self.timeout) as resp:
+                raw = resp.read().decode("utf-8")
+        except error.URLError as exc:
+            raise RuntimeError(
+                "Failed to contact Ollama server. "
+                "Ensure Ollama is running and OLLAMA_BASE_URL is correct."
+            ) from exc
+
+        data = json.loads(raw)
+        message = data.get("message") or {}
+        content = message.get("content", "")
+
+        if isinstance(content, dict):
+            return content
+
+        if not isinstance(content, str) or not content.strip():
+            raise ValueError("Ollama returned an empty response")
+
+        text = content.strip()
+        if text.startswith("```"):
+            lines = text.splitlines()
+            if len(lines) >= 3:
+                text = "\n".join(lines[1:-1]).strip()
+
+        return json.loads(text)
+
+    @staticmethod
+    def _example_config() -> Dict[str, Any]:
+        """Return a canonical example config (via MockLLM) for few-shot prompting."""
+        from sphinxsim.llm.mock_llm import MockLLM
+
+        return json.loads(MockLLM().generate("water dam break simulation").model_dump_json(exclude_none=True))
+
+    _BODY_TYPE_RULES: str = (
+        "STRICT RULES — you must follow these exactly: "
+        "(1) fluid_bodies may ONLY contain entries whose material.type is 'weakly_compressible_fluid'. "
+        "(2) solid_bodies may ONLY contain entries whose material.type is 'rigid_body'. "
+        "(3) observers[].variable.real_type must be a plain string such as 'Pressure', never a list. "
+        "(4) Return ONLY the JSON object — no markdown fences, no comments, no extra keys."
+    )
+
+    def generate(self, description: str) -> SimulationConfig:
+        if not description or not description.strip():
+            raise ValueError("description must not be empty")
+
+        system = (
+            "You are a simulator configuration generator. "
+            "Return ONLY valid JSON in exactly the same structure as 'example_output', "
+            "with values adapted for the new description. "
+        ) + self._BODY_TYPE_RULES
+        user = {
+            "description": description,
+            "example_output": self._example_config(),
+        }
+
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": json.dumps(user)},
+        ]
+        data = self._post_chat(messages=messages)
+        return SimulationConfig(**data)
+
+    def update(self, existing: SimulationConfig, description: str) -> SimulationConfig:
+        if not description or not description.strip():
+            raise ValueError("description must not be empty")
+
+        existing_json = existing.model_dump_json(exclude_none=True)
+        system = (
+            f"You revise simulator configurations. "
+            f"The update instruction is: \"{description}\". "
+            f"Apply it to the JSON config the user provides and return ONLY the full updated JSON "
+            f"in the same structure, with only the requested changes applied. "
+        ) + self._BODY_TYPE_RULES
+
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": existing_json},
+        ]
+        data = self._post_chat(messages=messages)
+        return SimulationConfig(**data)

--- a/sphinxsim/llm/ollama_llm.py
+++ b/sphinxsim/llm/ollama_llm.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from typing import Any, Dict
 from urllib import error, request
@@ -21,14 +22,14 @@ class OllamaLLM:
     def _endpoint(self) -> str:
         return f"{self.base_url.rstrip('/')}/api/chat"
 
-    def _post_chat(self, *, messages: list) -> Dict[str, Any]:
+    def _post_chat(self, *, messages: list, format_json: bool = True) -> Any:
         payload = {
             "model": self.model,
             "stream": False,
-            # Ask Ollama to return a JSON object in message.content.
-            "format": "json",
             "messages": messages,
         }
+        if format_json:
+            payload["format"] = "json"
 
         body = json.dumps(payload).encode("utf-8")
         req = request.Request(
@@ -63,14 +64,79 @@ class OllamaLLM:
             if len(lines) >= 3:
                 text = "\n".join(lines[1:-1]).strip()
 
+        if not format_json:
+            return text
+
         return json.loads(text)
 
     @staticmethod
-    def _example_config() -> Dict[str, Any]:
-        """Return a canonical example config (via MockLLM) for few-shot prompting."""
+    def _example_config(description: str) -> Dict[str, Any]:
+        """Return a physics-matched canonical example config for few-shot prompting."""
         from sphinxsim.llm.mock_llm import MockLLM
 
-        return json.loads(MockLLM().generate("water dam break simulation").model_dump_json(exclude_none=True))
+        return json.loads(MockLLM().generate(description).model_dump_json(exclude_none=True))
+
+    @staticmethod
+    def _merge_dicts(base: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, Any]:
+        merged = dict(base)
+        for key, value in updates.items():
+            if isinstance(value, dict) and isinstance(merged.get(key), dict):
+                merged[key] = OllamaLLM._merge_dicts(merged[key], value)
+            elif isinstance(value, list) and isinstance(merged.get(key), list):
+                base_list = merged[key]
+                if all(isinstance(item, dict) for item in value) and all(
+                    isinstance(item, dict) for item in base_list[: len(value)]
+                ):
+                    merged[key] = [
+                        OllamaLLM._merge_dicts(base_item, update_item)
+                        for base_item, update_item in zip(base_list, value)
+                    ] + base_list[len(value) :]
+                else:
+                    merged[key] = value
+            else:
+                merged[key] = value
+        return merged
+
+    @staticmethod
+    def _apply_explicit_instruction_overrides(cfg: Dict[str, Any], description: str) -> Dict[str, Any]:
+        updated = json.loads(json.dumps(cfg))
+
+        time_match = re.search(
+            r"(\d+(?:\.\d+)?)\s*(?:s|sec|secs|second|seconds)\b",
+            description,
+            re.IGNORECASE,
+        )
+        if time_match:
+            updated.setdefault("solver_parameters", {})["end_time"] = float(time_match.group(1))
+
+        res_match = re.search(r"(\d+(?:\.\d+)?)\s*mm\s+resolution", description, re.IGNORECASE)
+        if res_match:
+            updated.setdefault("geometries", {}).setdefault("global_resolution", {})["particle_spacing"] = (
+                float(res_match.group(1)) / 1000.0
+            )
+
+        return updated
+
+    @staticmethod
+    def _sanitize_config_dict(cfg: Dict[str, Any]) -> Dict[str, Any]:
+        updated = json.loads(json.dumps(cfg))
+        settings = updated.get("particle_generation", {}).get("settings", {})
+        bodies = settings.get("bodies", [])
+        fluid_names = {body.get("name") for body in updated.get("fluid_bodies", [])}
+        solid_names = {body.get("name") for body in updated.get("solid_bodies", [])}
+
+        for body in bodies:
+            if not isinstance(body, dict):
+                continue
+            name = body.get("name")
+            solid_body = body.get("solid_body")
+
+            if name in solid_names:
+                body["solid_body"] = {} if not isinstance(solid_body, dict) else solid_body
+            elif name in fluid_names and not isinstance(solid_body, dict):
+                body.pop("solid_body", None)
+
+        return updated
 
     _BODY_TYPE_RULES: str = (
         "STRICT RULES — you must follow these exactly: "
@@ -88,10 +154,11 @@ class OllamaLLM:
             "You are a simulator configuration generator. "
             "Return ONLY valid JSON in exactly the same structure as 'example_output', "
             "with values adapted for the new description. "
+            "Choose the correct simulation type and body/material families for the requested physics. "
         ) + self._BODY_TYPE_RULES
         user = {
             "description": description,
-            "example_output": self._example_config(),
+            "example_output": self._example_config(description),
         }
 
         messages = [
@@ -99,18 +166,25 @@ class OllamaLLM:
             {"role": "user", "content": json.dumps(user)},
         ]
         data = self._post_chat(messages=messages)
-        return SimulationConfig(**data)
+        if not isinstance(data, dict):
+            raise ValueError("Ollama returned an invalid generation response")
+        merged = self._merge_dicts(self._example_config(description), data)
+        merged = self._sanitize_config_dict(merged)
+        return SimulationConfig(**merged)
 
     def update(self, existing: SimulationConfig, description: str) -> SimulationConfig:
         if not description or not description.strip():
             raise ValueError("description must not be empty")
 
-        existing_json = existing.model_dump_json(exclude_none=True)
+        existing_dict = existing.model_dump(exclude_none=True)
+        existing_json = json.dumps(existing_dict)
         system = (
             f"You revise simulator configurations. "
             f"The update instruction is: \"{description}\". "
             f"Apply it to the JSON config the user provides and return ONLY the full updated JSON "
             f"in the same structure, with only the requested changes applied. "
+            f"Preserve all existing fields unless the instruction explicitly changes them. "
+            f"Do not remove arrays like geometries.shapes or body definitions. "
         ) + self._BODY_TYPE_RULES
 
         messages = [
@@ -118,4 +192,52 @@ class OllamaLLM:
             {"role": "user", "content": existing_json},
         ]
         data = self._post_chat(messages=messages)
-        return SimulationConfig(**data)
+        if not isinstance(data, dict):
+            raise ValueError("Ollama returned an invalid update response")
+        merged = self._merge_dicts(existing_dict, data)
+        if merged == existing_dict:
+            patch_system = (
+                f"You revise simulator configurations. The instruction is: \"{description}\". "
+                f"Return ONLY a minimal JSON patch object containing changed fields. "
+                f"Examples: {{\"solver_parameters\": {{\"end_time\": 2.0}}}} or "
+                f"{{\"geometries\": {{\"global_resolution\": {{\"particle_spacing\": 0.005}}}}}}."
+            )
+            patch_user = {
+                "instruction": description,
+                "existing_config": existing_dict,
+            }
+            patch_data = self._post_chat(
+                messages=[
+                    {"role": "system", "content": patch_system},
+                    {"role": "user", "content": json.dumps(patch_user)},
+                ]
+            )
+            if isinstance(patch_data, dict):
+                merged = self._merge_dicts(existing_dict, patch_data)
+        merged = self._apply_explicit_instruction_overrides(merged, description)
+        merged = self._sanitize_config_dict(merged)
+        return SimulationConfig(**merged)
+
+    def explore(self, question: str, context: str | None = None) -> str:
+        if not question or not question.strip():
+            raise ValueError("question must not be empty")
+
+        system = (
+            "You explain SPHinXsim schema and simulator functionality. "
+            "Answer in plain text. Be concise, accurate, and practical."
+        )
+        user = {
+            "question": question,
+            "context": context or "",
+        }
+
+        answer = self._post_chat(
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": json.dumps(user)},
+            ],
+            format_json=False,
+        )
+        if not isinstance(answer, str) or not answer.strip():
+            raise ValueError("Ollama returned an invalid exploration answer")
+        return answer.strip()

--- a/sphinxsim/llm/openai_llm.py
+++ b/sphinxsim/llm/openai_llm.py
@@ -83,4 +83,32 @@ class OpenAILLM:
         content = resp.choices[0].message.content or ""
         data: Dict[str, Any] = json.loads(content)
         return SimulationConfig(**data)
+
+    def explore(self, question: str, context: str | None = None) -> str:
+        if not question or not question.strip():
+            raise ValueError("question must not be empty")
+
+        system = (
+            "You explain SPHinXsim schema and simulator functionality. "
+            "Be accurate, concise, and practical."
+        )
+        user = {
+            "question": question,
+            "context": context or "",
+        }
+
+        resp = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": json.dumps(user)},
+            ],
+            temperature=0,
+        )
+
+        content = resp.choices[0].message.content or ""
+        answer = content.strip()
+        if not answer:
+            raise ValueError("OpenAI returned an empty exploration answer")
+        return answer
     

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -286,6 +286,30 @@ class TestCLIShell:
         err = capsys.readouterr().err
         assert "Run generate first" in err
 
+    def test_shell_explore_returns_answer(self, build_temp_path, capsys):
+        cfg = build_temp_path / "shell_config.json"
+        inputs = ['explore "what are top-level schema fields?"', "exit"]
+        with patch("builtins.input", side_effect=inputs):
+            rc = main(["shell", "--config", str(cfg)])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Top-level SimulationConfig fields" in out
+
+
+class TestCLIExplore:
+    def test_explore_outputs_schema_guidance(self, capsys):
+        rc = main(["explore", "what can I configure in SimulationConfig?"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Top-level SimulationConfig fields" in out
+
+    def test_explore_empty_question_returns_nonzero(self, capsys):
+        rc = main(["explore", ""])
+        assert rc != 0
+        err = capsys.readouterr().err
+        assert "question must not be empty" in err
+
 
 class TestCLIVersion:
     def test_version_matches_package(self, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -256,6 +256,37 @@ class TestCLIUpdate:
         assert rc != 0
 
 
+class TestCLIShell:
+    def test_shell_generate_then_update_auto_validates(self, build_temp_path, capsys):
+        cfg = build_temp_path / "shell_config.json"
+        inputs = [
+            'generate "water dam break simulation"',
+            'update "simulate for 2 s"',
+            "exit",
+        ]
+        with patch("builtins.input", side_effect=inputs):
+            rc = main(["shell", "--config", str(cfg)])
+
+        assert rc == 0
+        assert cfg.exists()
+        data = json.loads(cfg.read_text())
+        assert data["fluid_bodies"][0]["name"] == "WaterBody"
+        assert data["solver_parameters"]["end_time"] == pytest.approx(2.0)
+
+        out = capsys.readouterr().out
+        assert "Auto-validation passed" in out
+
+    def test_shell_update_before_generate_errors(self, build_temp_path, capsys):
+        cfg = build_temp_path / "missing_config.json"
+        inputs = ['update "simulate for 2 s"', "exit"]
+        with patch("builtins.input", side_effect=inputs):
+            rc = main(["shell", "--config", str(cfg)])
+
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "Run generate first" in err
+
+
 class TestCLIVersion:
     def test_version_matches_package(self, capsys):
         with pytest.raises(SystemExit) as exc_info:

--- a/tests/test_ollama_llm.py
+++ b/tests/test_ollama_llm.py
@@ -1,0 +1,226 @@
+"""Tests for OllamaLLM (HTTP calls are fully mocked)."""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+from urllib import error as urllib_error
+
+import pytest
+from pydantic import ValidationError
+
+from sphinxsim.config.schemas import SimulationConfig
+from sphinxsim.llm.mock_llm import MockLLM
+from sphinxsim.llm.ollama_llm import OllamaLLM
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_raw(config: SimulationConfig) -> Dict[str, Any]:
+    """Return the Ollama /api/chat JSON envelope wrapping *config*."""
+    return {
+        "message": {
+            "role": "assistant",
+            "content": config.model_dump_json(exclude_none=True),
+        }
+    }
+
+
+def _make_response(payload: Dict[str, Any]):
+    """Return a context-manager mock that reads *payload* as UTF-8 bytes."""
+    raw = json.dumps(payload).encode("utf-8")
+    resp = MagicMock()
+    resp.read.return_value = raw
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+# Canonical valid configs produced by the mock LLM (schema-correct by design).
+_FLUID_CONFIG = MockLLM().generate("water dam break simulation")
+_SOLID_CONFIG = MockLLM().generate("elastic beam bending under load")
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaLLMInit:
+    def test_defaults(self):
+        llm = OllamaLLM()
+        assert llm.base_url == "http://localhost:11434"
+        assert llm.model == "qwen2.5:3b"
+        assert llm.timeout == 60.0
+
+    def test_custom_values(self):
+        llm = OllamaLLM(base_url="http://myserver:11434", model="llama3", timeout=30.0)
+        assert llm.base_url == "http://myserver:11434"
+        assert llm.model == "llama3"
+        assert llm.timeout == 30.0
+
+    def test_endpoint_strips_trailing_slash(self):
+        llm = OllamaLLM(base_url="http://localhost:11434/")
+        assert llm._endpoint() == "http://localhost:11434/api/chat"
+
+
+# ---------------------------------------------------------------------------
+# generate()
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaLLMGenerate:
+    def setup_method(self):
+        self.llm = OllamaLLM()
+
+    def test_returns_simulation_config(self):
+        resp = _make_response(_mock_raw(_FLUID_CONFIG))
+        with patch("urllib.request.urlopen", return_value=resp):
+            cfg = self.llm.generate("water dam break simulation")
+        assert isinstance(cfg, SimulationConfig)
+
+    def test_result_is_schema_valid(self):
+        resp = _make_response(_mock_raw(_FLUID_CONFIG))
+        with patch("urllib.request.urlopen", return_value=resp):
+            cfg = self.llm.generate("water dam break simulation")
+        restored = SimulationConfig.model_validate_json(cfg.model_dump_json())
+        assert restored == cfg
+
+    def test_empty_description_raises(self):
+        with pytest.raises(ValueError, match="description must not be empty"):
+            self.llm.generate("")
+
+    def test_whitespace_description_raises(self):
+        with pytest.raises(ValueError):
+            self.llm.generate("   ")
+
+    def test_correct_endpoint_called(self):
+        resp = _make_response(_mock_raw(_FLUID_CONFIG))
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            self.llm.generate("water flow")
+        req = mock_open.call_args[0][0]
+        assert req.full_url == "http://localhost:11434/api/chat"
+        assert req.method == "POST"
+
+    def test_request_contains_description(self):
+        resp = _make_response(_mock_raw(_FLUID_CONFIG))
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            self.llm.generate("water flow through a pipe")
+        req = mock_open.call_args[0][0]
+        body = json.loads(req.data.decode("utf-8"))
+        user_content = json.loads(body["messages"][1]["content"])
+        assert "water flow through a pipe" in user_content["description"]
+
+    def test_request_payload_has_format_json(self):
+        resp = _make_response(_mock_raw(_FLUID_CONFIG))
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            self.llm.generate("water flow")
+        body = json.loads(mock_open.call_args[0][0].data.decode("utf-8"))
+        assert body.get("format") == "json"
+
+    def test_request_payload_stream_false(self):
+        resp = _make_response(_mock_raw(_FLUID_CONFIG))
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            self.llm.generate("water flow")
+        body = json.loads(mock_open.call_args[0][0].data.decode("utf-8"))
+        assert body["stream"] is False
+
+    def test_request_includes_example_output(self):
+        resp = _make_response(_mock_raw(_FLUID_CONFIG))
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            self.llm.generate("water flow")
+        body = json.loads(mock_open.call_args[0][0].data.decode("utf-8"))
+        user_content = json.loads(body["messages"][1]["content"])
+        assert "example_output" in user_content
+
+    def test_network_error_raises_runtime_error(self):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib_error.URLError("connection refused"),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to contact Ollama server"):
+                self.llm.generate("water flow")
+
+    def test_empty_content_raises(self):
+        resp = _make_response({"message": {"role": "assistant", "content": ""}})
+        with patch("urllib.request.urlopen", return_value=resp):
+            with pytest.raises(ValueError, match="Ollama returned an empty response"):
+                self.llm.generate("water flow")
+
+    def test_fenced_json_is_stripped(self):
+        fenced = "```json\n" + _FLUID_CONFIG.model_dump_json(exclude_none=True) + "\n```"
+        resp = _make_response({"message": {"role": "assistant", "content": fenced}})
+        with patch("urllib.request.urlopen", return_value=resp):
+            cfg = self.llm.generate("water flow")
+        assert isinstance(cfg, SimulationConfig)
+
+    def test_dict_content_accepted_directly(self):
+        """Ollama may occasionally return JSON already decoded as a dict."""
+        raw_dict = json.loads(_FLUID_CONFIG.model_dump_json(exclude_none=True))
+        resp = _make_response({"message": {"role": "assistant", "content": raw_dict}})
+        with patch("urllib.request.urlopen", return_value=resp):
+            cfg = self.llm.generate("water flow")
+        assert isinstance(cfg, SimulationConfig)
+
+    def test_custom_model_sent_in_request(self):
+        llm = OllamaLLM(model="llama3")
+        resp = _make_response(_mock_raw(_FLUID_CONFIG))
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            llm.generate("water flow")
+        body = json.loads(mock_open.call_args[0][0].data.decode("utf-8"))
+        assert body["model"] == "llama3"
+
+
+# ---------------------------------------------------------------------------
+# update()
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaLLMUpdate:
+    def setup_method(self):
+        self.llm = OllamaLLM()
+
+    def test_returns_simulation_config(self):
+        resp = _make_response(_mock_raw(_FLUID_CONFIG))
+        with patch("urllib.request.urlopen", return_value=resp):
+            cfg = self.llm.update(_FLUID_CONFIG, "simulate for 3 s")
+        assert isinstance(cfg, SimulationConfig)
+
+    def test_empty_description_raises(self):
+        with pytest.raises(ValueError, match="description must not be empty"):
+            self.llm.update(_FLUID_CONFIG, "")
+
+    def test_whitespace_description_raises(self):
+        with pytest.raises(ValueError):
+            self.llm.update(_FLUID_CONFIG, "   ")
+
+    def test_request_contains_existing_config(self):
+        resp = _make_response(_mock_raw(_FLUID_CONFIG))
+        with patch("urllib.request.urlopen", return_value=resp) as mock_open:
+            self.llm.update(_FLUID_CONFIG, "simulate for 3 s")
+        body = json.loads(mock_open.call_args[0][0].data.decode("utf-8"))
+        # The instruction is embedded in the system message; the user message is the raw config JSON.
+        system_content = body["messages"][0]["content"]
+        assert "simulate for 3 s" in system_content
+        # User message is the existing config serialised as JSON.
+        user_content = json.loads(body["messages"][1]["content"])
+        assert "simulation_type" in user_content
+
+    def test_result_is_schema_valid(self):
+        resp = _make_response(_mock_raw(_SOLID_CONFIG))
+        with patch("urllib.request.urlopen", return_value=resp):
+            cfg = self.llm.update(_SOLID_CONFIG, "set end time to 2 s")
+        restored = SimulationConfig.model_validate_json(cfg.model_dump_json())
+        assert restored == cfg
+
+    def test_network_error_raises_runtime_error(self):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib_error.URLError("connection refused"),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to contact Ollama server"):
+                self.llm.update(_FLUID_CONFIG, "change model")

--- a/tests/test_ollama_llm.py
+++ b/tests/test_ollama_llm.py
@@ -202,7 +202,7 @@ class TestOllamaLLMUpdate:
         resp = _make_response(_mock_raw(_FLUID_CONFIG))
         with patch("urllib.request.urlopen", return_value=resp) as mock_open:
             self.llm.update(_FLUID_CONFIG, "simulate for 3 s")
-        body = json.loads(mock_open.call_args[0][0].data.decode("utf-8"))
+        body = json.loads(mock_open.call_args_list[0][0][0].data.decode("utf-8"))
         # The instruction is embedded in the system message; the user message is the raw config JSON.
         system_content = body["messages"][0]["content"]
         assert "simulate for 3 s" in system_content

--- a/tests/test_ollama_llm_integration.py
+++ b/tests/test_ollama_llm_integration.py
@@ -1,0 +1,75 @@
+"""Integration tests for OllamaLLM against a live Ollama server.
+
+These tests are:
+- Skipped automatically when the Ollama server is unreachable.
+- Skipped in CI environments (GitHub Actions, etc.) where Ollama is not available.
+- Run locally after sourcing setup-local-env.sh with SPHINXSIM_LLM_PROVIDER=ollama.
+
+To run locally:
+    SPHINXSIM_LLM_PROVIDER=ollama pytest tests/test_ollama_llm_integration.py -v
+
+To run all tests including mocked ones:
+    pytest tests/ -v
+"""
+
+from __future__ import annotations
+
+import os
+from urllib import error, request
+
+import pytest
+
+from sphinxsim.config.schemas import SimulationConfig
+from sphinxsim.llm import get_llm
+from sphinxsim.llm.ollama_llm import OllamaLLM
+
+
+def _ollama_reachable() -> bool:
+    base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+    try:
+        with request.urlopen(f"{base_url.rstrip('/')}/api/tags", timeout=3):
+            return True
+    except (error.URLError, OSError):
+        return False
+
+
+def _is_ci_environment() -> bool:
+    """Detect if running in a CI environment."""
+    return bool(os.getenv("CI") or os.getenv("GITHUB_ACTIONS") or os.getenv("GITLAB_CI"))
+
+
+skip_if_no_ollama = pytest.mark.skipif(
+    not _ollama_reachable() or _is_ci_environment(),
+    reason="Ollama server not reachable or running in CI environment",
+)
+
+
+@skip_if_no_ollama
+@pytest.mark.integration
+class TestOllamaLLMIntegration:
+    def setup_method(self):
+        self.llm = OllamaLLM(
+            base_url=os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
+            model=os.getenv("OLLAMA_MODEL", "qwen2.5:3b"),
+            timeout=120.0,
+        )
+
+    def test_generate_returns_valid_config(self):
+        cfg = self.llm.generate("simulate water flowing through a pipe")
+        assert isinstance(cfg, SimulationConfig)
+
+    def test_generate_schema_roundtrip(self):
+        cfg = self.llm.generate("dam break simulation")
+        restored = SimulationConfig.model_validate_json(cfg.model_dump_json())
+        assert restored == cfg
+
+    def test_update_returns_valid_config(self):
+        base = self.llm.generate("water flow")
+        updated = self.llm.update(base, "set end time to 2 s")
+        assert isinstance(updated, SimulationConfig)
+
+    def test_get_llm_returns_ollama_when_env_set(self, monkeypatch):
+        """get_llm() must resolve to OllamaLLM when SPHINXSIM_LLM_PROVIDER=ollama."""
+        monkeypatch.setenv("SPHINXSIM_LLM_PROVIDER", "ollama")
+        llm = get_llm()
+        assert isinstance(llm, OllamaLLM)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -133,6 +133,114 @@ class TestSimulationConfig:
         with pytest.raises(ValidationError, match="must match a shape name"):
             _make_minimal_fluid_config(**bad)
 
+    def test_shape_reference_to_previous_shape_is_allowed(self):
+        geometries = {
+            "system_domain": {"lower_bound": [0.0, 0.0], "upper_bound": [1.0, 1.0]},
+            "global_resolution": {"particle_spacing": 0.05},
+            "shapes": [
+                {
+                    "name": "WaterBody",
+                    "type": "bounding_box",
+                    "lower_bound": [0.0, 0.0],
+                    "upper_bound": [0.4, 0.2],
+                },
+                {
+                    "name": "ExpandedWaterBody",
+                    "type": "expanded_box",
+                    "original": "WaterBody",
+                    "expansion": 0.01,
+                },
+                {
+                    "name": "WallBoundary",
+                    "type": "bounding_box",
+                    "lower_bound": [0.0, 0.0],
+                    "upper_bound": [1.0, 1.0],
+                },
+            ],
+            "aligned_boxes": [
+                {
+                    "name": "Inlet",
+                    "type": "region",
+                    "half_size": [0.1, 0.05],
+                    "transform": {"translation": [0.05, 0.2], "rotation_angle": 0.0},
+                }
+            ],
+        }
+        cfg = _make_minimal_fluid_config(geometries=geometries)
+        assert any(shape.name == "ExpandedWaterBody" for shape in cfg.geometries.shapes)
+
+    def test_shape_duplicate_name_rejected(self):
+        geometries = {
+            "system_domain": {"lower_bound": [0.0, 0.0], "upper_bound": [1.0, 1.0]},
+            "global_resolution": {"particle_spacing": 0.05},
+            "shapes": [
+                {
+                    "name": "WaterBody",
+                    "type": "bounding_box",
+                    "lower_bound": [0.0, 0.0],
+                    "upper_bound": [0.4, 0.2],
+                },
+                {
+                    "name": "WaterBody",
+                    "type": "expanded_box",
+                    "original": "WaterBody",
+                    "expansion": 0.01,
+                },
+                {
+                    "name": "WallBoundary",
+                    "type": "bounding_box",
+                    "lower_bound": [0.0, 0.0],
+                    "upper_bound": [1.0, 1.0],
+                },
+            ],
+            "aligned_boxes": [
+                {
+                    "name": "Inlet",
+                    "type": "region",
+                    "half_size": [0.1, 0.05],
+                    "transform": {"translation": [0.05, 0.2], "rotation_angle": 0.0},
+                }
+            ],
+        }
+        with pytest.raises(ValidationError, match="duplicate shape name"):
+            _make_minimal_fluid_config(geometries=geometries)
+
+    def test_shape_reference_must_be_previously_defined(self):
+        geometries = {
+            "system_domain": {"lower_bound": [0.0, 0.0], "upper_bound": [1.0, 1.0]},
+            "global_resolution": {"particle_spacing": 0.05},
+            "shapes": [
+                {
+                    "name": "ExpandedWaterBody",
+                    "type": "expanded_box",
+                    "original": "WaterBody",
+                    "expansion": 0.01,
+                },
+                {
+                    "name": "WaterBody",
+                    "type": "bounding_box",
+                    "lower_bound": [0.0, 0.0],
+                    "upper_bound": [0.4, 0.2],
+                },
+                {
+                    "name": "WallBoundary",
+                    "type": "bounding_box",
+                    "lower_bound": [0.0, 0.0],
+                    "upper_bound": [1.0, 1.0],
+                },
+            ],
+            "aligned_boxes": [
+                {
+                    "name": "Inlet",
+                    "type": "region",
+                    "half_size": [0.1, 0.05],
+                    "transform": {"translation": [0.05, 0.2], "rotation_angle": 0.0},
+                }
+            ],
+        }
+        with pytest.raises(ValidationError, match="previously defined"):
+            _make_minimal_fluid_config(geometries=geometries)
+
     def test_observer_observed_body_must_exist(self):
         with pytest.raises(ValidationError, match="observer observed_body"):
             _make_minimal_fluid_config(


### PR DESCRIPTION
This pull request introduces robust support for local and CI testing of LLM-backed simulation config generation, with a particular focus on integrating and testing a new Ollama-based LLM provider. It adds a new `OllamaLLM` implementation, a comprehensive test matrix (including both mocked and live integration tests), and supporting documentation and configuration changes to ensure local development and CI pipelines remain deterministic and stable.

**LLM Provider Integration:**

* Added `OllamaLLM` provider in `sphinxsim/llm/ollama_llm.py`, supporting both config generation and update via a local Ollama server, with strict schema validation and error handling. (`[sphinxsim/llm/ollama_llm.pyR1-R121](diffhunk://#diff-212ffb18d364dbba857779bef2a324d8c52ec83e23c2ad37b99630d8a187a9dfR1-R121)`)
* Updated `sphinxsim/llm/__init__.py` to support dynamic selection of `OllamaLLM` based on the `SPHINXSIM_LLM_PROVIDER` environment variable. (`[sphinxsim/llm/__init__.pyR4-R52](diffhunk://#diff-d5da8fa591c57d6d85e91f7aa244c36f24f1afacac2aa0adaeaa4d7f04b97d1eR4-R52)`)

**Testing Infrastructure:**

* Added `tests/test_ollama_llm.py` for fully mocked tests of the Ollama provider, ensuring schema correctness and robust error handling without requiring a live server. (`[tests/test_ollama_llm.pyR1-R226](diffhunk://#diff-a3c5ef21aab8d9aea6fc18d6ca9662a3c82280283c0bf99645c99f7348f46106R1-R226)`)
* Added `tests/test_ollama_llm_integration.py` for integration tests against a live Ollama server, automatically skipped in CI or when Ollama is unavailable. (`[tests/test_ollama_llm_integration.pyR1-R75](diffhunk://#diff-f91722f4c77cd2a8a43df57b4086b28a8153f796d425fff1687695deeaff3a94R1-R75)`)
* Split `examples/test_nlp_to_simulation.py` into separate tests for the mock and Ollama providers, with environment detection and skipping logic for CI and missing dependencies. (`[[1]](diffhunk://#diff-0d7ff4cbc0b0767dca2ab43c9f42a26a358a33f2824afc31506cbe7511742d53L205-R245)`, `[[2]](diffhunk://#diff-0d7ff4cbc0b0767dca2ab43c9f42a26a358a33f2824afc31506cbe7511742d53R17-R19)`)
* Registered a new `integration` pytest marker in `pyproject.toml` for tests requiring live services. (`[pyproject.tomlR36-R38](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R36-R38)`)

**Documentation and Configuration:**

* Documented the LLM test matrix, environment variables, and local/CI behavior in `docs/llm-testing.md` and referenced it from the main index. (`[[1]](diffhunk://#diff-4cba9a3204d27d28b0dda9b1bb0318cde165fc085dd29ef335578adcec410a8aR1-R36)`, `[[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R57-R65)`)
* Updated `mkdocs.yml` to include the new LLM Testing documentation in the navigation. (`[mkdocs.ymlR3-R6](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R3-R6)`)
* Changed `setup-local-env.sh` to default to Ollama as the LLM provider for local development, with sensible defaults for Ollama server and model. (`[setup-local-env.shL8-R10](diffhunk://#diff-cce1a94abc1e16962a9394f5e47212b47e398db781290aaedc7cb09c3785a8fcL8-R10)`)

These changes ensure that LLM-backed simulation config generation is fully testable, robust, and easy to develop against, while keeping CI runs deterministic and free from external dependencies.