### PR TITLE
Xiangyu/revise kernel correction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           ctest --test-dir ${{ github.workspace }}/build-integrated \
             --output-on-failure \
-            -R "test_(2d|3d)_simulation$"
+            -L "simulation_class"
 
       - name: Install Python package (editable with dev dependencies)
         run: |
@@ -214,7 +214,7 @@ jobs:
         run: |
           ctest --test-dir "${{ github.workspace }}\\build-integrated" `
             --output-on-failure `
-            -R "test_(2d|3d)_simulation$"
+            -L "simulation_class"
 
       - name: Install Python package (editable with dev dependencies)
         shell: pwsh
@@ -307,7 +307,7 @@ jobs:
         run: |
           ctest --test-dir ${{ github.workspace }}/build-integrated \
             --output-on-failure \
-            -R "test_(2d|3d)_simulation$"
+            -L "simulation_class"
 
       - name: Install Python package (editable with dev dependencies)
         run: |

--- a/sphinxsim/sph_simulation/simulation_builder/base_simulation_builder.h
+++ b/sphinxsim/sph_simulation/simulation_builder/base_simulation_builder.h
@@ -106,7 +106,7 @@ enum class SimulationHookPoint
     ExtraOutput,
     ParticleSort,
     ParticleIndicationTagging,
-    AfterAdvectionStepSetup,
+    AfterLinearCorrectionMatrix,
     NumHooks
 };
 
@@ -115,7 +115,7 @@ enum class InitializationHookPoint
     InitialCondition,
     InitialObservation,
     InitialParticleIndicationTagging,
-    InitialAfterAdvectionStepSetup,
+    InitialAfterLinearCorrectionMatrix,
     NumHooks
 };
 

--- a/sphinxsim/sph_simulation/simulation_builder/fluid_simulation_builder.cpp
+++ b/sphinxsim/sph_simulation/simulation_builder/fluid_simulation_builder.cpp
@@ -43,10 +43,17 @@ void FluidSimulationBuilder::buildSimulation(SPHSimulation &sim, const json &con
     //----------------------------------------------------------------------
     // Define the main numerical methods used in the simulation.
     // Note that there may be data dependence on the sequence of constructions.
+    //----------------------------------------------------------------------
+    auto &main_methods = sph_solver.addParticleMethodContainer(par_ck);
+    //----------------------------------------------------------------------
+    // Define dependent optional methods using hooking point in stage pipelines.
+    //----------------------------------------------------------------------
+    buildSurfaceIndicationIfOpenBoundary(sim, main_methods, fluid_inner, fluid_wall_contact);
+    //----------------------------------------------------------------------
+    // The essential main methods used for the simulation.
     // Generally, the configuration dynamics, such as update cell linked list,
     // update body relations, are defined first.
     //----------------------------------------------------------------------
-    auto &main_methods = sph_solver.addParticleMethodContainer(par_ck);
     auto &solid_cell_linked_list = main_methods.addCellLinkedListDynamics(solid_bodies);
     auto &fluid_configuration =
         main_methods.addParticleDynamicsGroup()
@@ -81,11 +88,10 @@ void FluidSimulationBuilder::buildSimulation(SPHSimulation &sim, const json &con
     auto &state_recording_trigger = time_stepper.addTriggerByInterval(solver_common_config.output_interval_);
     time_stepper.setScreeningInterval(solver_common_config.screen_interval_);
     //----------------------------------------------------------------------
-    // Define optional methods using hooking point in stage pipelines.
+    // Define dependent optional methods using hooking point in stage pipelines.
     //----------------------------------------------------------------------
     recording_builder.buildObservationIfPresent(sim, main_methods, config);
     buildExternalForceIfPresent(sim, main_methods, fluid_body, config);
-    buildSurfaceIndicationIfOpenBoundary(sim, main_methods, fluid_inner, fluid_wall_contact);
     buildTransportVelocityFormulationIfNotFreeSurface(sim, main_methods, fluid_inner, fluid_wall_contact);
     buildViscousForceIfPresent(sim, main_methods, fluid_inner, fluid_wall_contact);
     buildBoundaryConditionsIfPresent(sim, main_methods, config);

--- a/sphinxsim/sph_simulation/simulation_builder/fluid_simulation_builder.cpp
+++ b/sphinxsim/sph_simulation/simulation_builder/fluid_simulation_builder.cpp
@@ -56,9 +56,8 @@ void FluidSimulationBuilder::buildSimulation(SPHSimulation &sim, const json &con
     auto &fluid_advection_step_setup = main_methods.addStateDynamics<fluid_dynamics::AdvectionStepSetup>(fluid_body);
     auto &fluid_particle_position = main_methods.addStateDynamics<fluid_dynamics::UpdateParticlePosition>(fluid_body);
 
-    auto &fluid_linear_correction_matrix =
-        main_methods.addInteractionDynamics<LinearCorrectionMatrix, WithUpdate>(fluid_inner, 0.5)
-            .addPostContactInteraction(fluid_wall_contact);
+    auto &fluid_linear_correction_matrix = addLinearCorrectionMatrixWithScope(
+        config_manager, main_methods, fluid_inner, fluid_wall_contact);
 
     auto &fluid_acoustic_step_1st_half = addAcousticStep1stHalf(
         config_manager, main_methods, fluid_inner, fluid_wall_contact);
@@ -110,11 +109,11 @@ void FluidSimulationBuilder::buildSimulation(SPHSimulation &sim, const json &con
             solid_cell_linked_list.exec();
             fluid_configuration.exec();
 
-            fluid_linear_correction_matrix.exec();
             initialization_pipeline.run_hooks(InitializationHookPoint::InitialParticleIndicationTagging);
             fluid_density_regularization.exec();
             fluid_advection_step_setup.exec();
-            initialization_pipeline.run_hooks(InitializationHookPoint::InitialAfterAdvectionStepSetup);
+            fluid_linear_correction_matrix.exec();
+            initialization_pipeline.run_hooks(InitializationHookPoint::InitialAfterLinearCorrectionMatrix);
 
             initialization_pipeline.run_hooks(InitializationHookPoint::InitialObservation);
             body_state_recorder.writeToFile();
@@ -173,11 +172,11 @@ void FluidSimulationBuilder::buildSimulation(SPHSimulation &sim, const json &con
                 simulation_pipeline.run_hooks(SimulationHookPoint::ParticleSort);
 
                 fluid_configuration.exec();
-                fluid_linear_correction_matrix.exec();
                 simulation_pipeline.run_hooks(SimulationHookPoint::ParticleIndicationTagging);
                 fluid_density_regularization.exec();
                 fluid_advection_step_setup.exec();
-                simulation_pipeline.run_hooks(SimulationHookPoint::AfterAdvectionStepSetup);
+                fluid_linear_correction_matrix.exec();
+                simulation_pipeline.run_hooks(SimulationHookPoint::AfterLinearCorrectionMatrix);
             }
         });
 }

--- a/sphinxsim/sph_simulation/simulation_builder/fluid_simulation_builder.h
+++ b/sphinxsim/sph_simulation/simulation_builder/fluid_simulation_builder.h
@@ -91,6 +91,11 @@ class FluidSimulationBuilder : public SimulationBuilder
         SPHSimulation &sim, MethodContainerType &main_methods,
         InnerRelationType &inner_relation, ContactRelationType &contact_relation);
 
+    template <class MethodContainerType, class InnerRelationType, class ContactRelationType>
+    BaseDynamics<void> &addLinearCorrectionMatrixWithScope(
+        EntityManager &config_manager, MethodContainerType &main_methods,
+        InnerRelationType &inner_relation, ContactRelationType &contact_relation);
+
     template <class KernelGradientIntegralType>
     void addTransportVelocityCorrection(
         KernelGradientIntegralType &kernel_gradient_integral,

--- a/sphinxsim/sph_simulation/simulation_builder/fluid_simulation_builder.hpp
+++ b/sphinxsim/sph_simulation/simulation_builder/fluid_simulation_builder.hpp
@@ -150,7 +150,7 @@ BaseDynamics<void> &FluidSimulationBuilder::addLinearCorrectionMatrixWithScope(
     auto &fluid_linear_correction_matrix = main_methods.addParticleDynamicsGroup();
     fluid_linear_correction_matrix.add(
         &main_methods.template addInteractionDynamicsWithUpdate<LinearCorrectionMatrix>(inner_relation, 0.5)
-             .template addPostContactInteraction(contact_relation));
+             .addPostContactInteraction(contact_relation));
 
     auto &fluid_solver_config = config_manager.getEntity<FluidSolverConfig>("FluidSolverConfig");
     if (fluid_solver_config.surface_type_ == "open_boundary")

--- a/sphinxsim/sph_simulation/simulation_builder/fluid_simulation_builder.hpp
+++ b/sphinxsim/sph_simulation/simulation_builder/fluid_simulation_builder.hpp
@@ -143,6 +143,29 @@ BaseDynamics<void> &FluidSimulationBuilder::addDensityRegularization(
 }
 //=================================================================================================//
 template <class MethodContainerType, class InnerRelationType, class ContactRelationType>
+BaseDynamics<void> &FluidSimulationBuilder::addLinearCorrectionMatrixWithScope(
+    EntityManager &config_manager, MethodContainerType &main_methods,
+    InnerRelationType &inner_relation, ContactRelationType &contact_relation)
+{
+    auto &fluid_linear_correction_matrix = main_methods.addParticleDynamicsGroup();
+    fluid_linear_correction_matrix.add(
+        &main_methods.template addInteractionDynamicsWithUpdate<LinearCorrectionMatrix>(inner_relation, 0.5)
+             .template addPostContactInteraction(contact_relation));
+
+    auto &fluid_solver_config = config_manager.getEntity<FluidSolverConfig>("FluidSolverConfig");
+
+    if (fluid_solver_config.surface_type_ == "open_boundary")
+    {
+        SPHBody &sph_body = inner_relation.getSPHBody();
+        sph_body.getBaseParticles().template registerStateVariable<int>("Indicator", 0);
+        fluid_linear_correction_matrix.add(
+            &main_methods.template addStateDynamics<LinearCorrectionMatrixScope, BulkParticles>(sph_body));
+    }
+
+    return fluid_linear_correction_matrix;
+}
+//=================================================================================================//
+template <class MethodContainerType, class InnerRelationType, class ContactRelationType>
 void FluidSimulationBuilder::buildTransportVelocityFormulationIfNotFreeSurface(
     SPHSimulation &sim, MethodContainerType &main_methods,
     InnerRelationType &inner_relation, ContactRelationType &contact_relation)
@@ -162,12 +185,12 @@ void FluidSimulationBuilder::buildTransportVelocityFormulationIfNotFreeSurface(
 
         auto &initialization_pipeline = sim.getInitializationPipeline();
         initialization_pipeline.insert_hook(
-            InitializationHookPoint::InitialAfterAdvectionStepSetup, [&]()
+            InitializationHookPoint::InitialAfterLinearCorrectionMatrix, [&]()
             { transport_velocity_correction.exec(); });
 
         auto &simulation_pipeline = sim.getSimulationPipeline();
         simulation_pipeline.insert_hook(
-            SimulationHookPoint::AfterAdvectionStepSetup, [&]()
+            SimulationHookPoint::AfterLinearCorrectionMatrix, [&]()
             { transport_velocity_correction.exec(); });
     }
 }
@@ -210,12 +233,12 @@ void FluidSimulationBuilder::buildViscousForceIfPresent(
 
         auto &initialization_pipeline = sim.getInitializationPipeline();
         initialization_pipeline.insert_hook(
-            InitializationHookPoint::InitialAfterAdvectionStepSetup, [&]()
+            InitializationHookPoint::InitialAfterLinearCorrectionMatrix, [&]()
             { viscous_force.exec(); });
 
         auto &simulation_pipeline = sim.getSimulationPipeline();
         simulation_pipeline.insert_hook(
-            SimulationHookPoint::AfterAdvectionStepSetup, [&]()
+            SimulationHookPoint::AfterLinearCorrectionMatrix, [&]()
             { viscous_force.exec(); });
     }
 }

--- a/sphinxsim/sph_simulation/simulation_builder/fluid_simulation_builder.hpp
+++ b/sphinxsim/sph_simulation/simulation_builder/fluid_simulation_builder.hpp
@@ -153,13 +153,11 @@ BaseDynamics<void> &FluidSimulationBuilder::addLinearCorrectionMatrixWithScope(
              .template addPostContactInteraction(contact_relation));
 
     auto &fluid_solver_config = config_manager.getEntity<FluidSolverConfig>("FluidSolverConfig");
-
     if (fluid_solver_config.surface_type_ == "open_boundary")
     {
-        SPHBody &sph_body = inner_relation.getSPHBody();
-        sph_body.getBaseParticles().template registerStateVariable<int>("Indicator", 0);
         fluid_linear_correction_matrix.add(
-            &main_methods.template addStateDynamics<LinearCorrectionMatrixScope, BulkParticles>(sph_body));
+            &main_methods.template addStateDynamics<LinearCorrectionMatrixScope, BulkParticles>(
+                inner_relation.getSPHBody()));
     }
 
     return fluid_linear_correction_matrix;

--- a/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.cpp
+++ b/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.cpp
@@ -17,14 +17,6 @@ BufferIndicationCK::BufferIndicationCK(OrientedBoxByCell &oriented_box_part)
     particles_->addEvolvingVariable<int>("BufferIndicator");
 }
 //=================================================================================================//
-ResetBufferCorrectionMatrixCK::ResetBufferCorrectionMatrixCK(OrientedBoxByCell &oriented_box_part)
-    : BaseLocalDynamics<OrientedBoxByCell>(oriented_box_part),
-      sv_oriented_box_(oriented_box_part.svOrientedBox()),
-      dv_pos_(particles_->getVariableByName<Vecd>("Position")),
-      dv_B_(particles_->registerStateVariable<Matd>(
-          "LinearCorrectionMatrix", IdentityMatrix<Matd>::value)),
-      radius_(sph_body_->getSPHAdaptation().getKernel()->CutOffRadius()) {}
-//=================================================================================================//
 BufferOutflowIndication::BufferOutflowIndication(OrientedBoxByCell &oriented_box_part)
     : BaseLocalDynamics<OrientedBoxByCell>(oriented_box_part),
       part_id_(oriented_box_part.getPartID()),

--- a/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h
+++ b/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h
@@ -68,33 +68,6 @@ class BufferIndicationCK : public BaseLocalDynamics<OrientedBoxByCell>
     DiscreteVariable<int> *dv_buffer_indicator_;
 };
 
-class ResetBufferCorrectionMatrixCK : public BaseLocalDynamics<OrientedBoxByCell>
-{
-  private:
-    SingleVariable<OrientedBox> *sv_oriented_box_;
-    DiscreteVariable<Vecd> *dv_pos_;
-    DiscreteVariable<Matd> *dv_B_;
-    Real radius_;
-
-  public:
-    explicit ResetBufferCorrectionMatrixCK(OrientedBoxByCell &oriented_box_part);
-    virtual ~ResetBufferCorrectionMatrixCK() {};
-
-    class UpdateKernel
-    {
-      public:
-        template <class ExecutionPolicy, class EncloserType>
-        UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
-
-      protected:
-        OrientedBox *oriented_box_;
-        Vecd *pos_;
-        Matd *B_;
-        Real radius_;
-    };
-};
-
 template <class ConditionType>
 class BufferInflowInjectionCK : public BaseLocalDynamics<OrientedBoxByCell>
 {
@@ -303,7 +276,6 @@ template <typename ExecutionPolicy, class KernelCorrectionType, class ConditionT
 class BidirectionalBoundaryCK : public AbstractBidirectionalBoundary
 {
     StateDynamics<ExecutionPolicy, BufferIndicationCK> tag_buffer_particles_;
-    StateDynamics<ExecutionPolicy, ResetBufferCorrectionMatrixCK> reset_buffer_correction_matrix_;
     StateDynamics<ExecutionPolicy, PressureVelocityCondition<KernelCorrectionType, ConditionType>> boundary_condition_;
     StateDynamics<ExecutionPolicy, BufferInflowInjectionCK<ConditionType>> inflow_injection_;
     StateDynamics<ExecutionPolicy, BufferOutflowIndication> outflow_indication_;
@@ -312,11 +284,7 @@ class BidirectionalBoundaryCK : public AbstractBidirectionalBoundary
     template <typename... Args>
     BidirectionalBoundaryCK(OrientedBoxByCell &oriented_box_part, Args &&...args);
 
-    virtual void tagBufferParticles() override
-    {
-        tag_buffer_particles_.exec();
-        reset_buffer_correction_matrix_.exec();
-    }
+    virtual void tagBufferParticles() override { tag_buffer_particles_.exec(); }
 
     virtual void applyBoundaryCondition(Real dt) override
     {
@@ -324,6 +292,7 @@ class BidirectionalBoundaryCK : public AbstractBidirectionalBoundary
         for (size_t k = 0; k < this->supplementary_conditions_.size(); ++k)
             supplementary_conditions_[k]->exec(dt);
     }
+
     virtual void injectParticles() override { inflow_injection_.exec(); }
     virtual void indicateOutFlowParticles() override { outflow_indication_.exec(); }
 };

--- a/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.hpp
+++ b/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.hpp
@@ -26,22 +26,6 @@ inline void BufferIndicationCK::UpdateKernel::update(size_t index_i, Real dt)
     }
 }
 //=================================================================================================//
-template <class ExecutionPolicy, class EncloserType>
-ResetBufferCorrectionMatrixCK::UpdateKernel::UpdateKernel(
-    const ExecutionPolicy &ex_policy, EncloserType &encloser)
-    : oriented_box_(encloser.sv_oriented_box_->DelegatedData(ex_policy)),
-      pos_(encloser.dv_pos_->DelegatedData(ex_policy)),
-      B_(encloser.dv_B_->DelegatedData(ex_policy)),
-      radius_(encloser.radius_) {}
-//=================================================================================================//
-inline void ResetBufferCorrectionMatrixCK::UpdateKernel::update(size_t index_i, Real dt)
-{
-    if (oriented_box_->checkLowerBound(pos_[index_i], -radius_))
-    {
-        B_[index_i] = Matd::Identity();
-    }
-}
-//=================================================================================================//
 template <class ConditionType>
 template <typename... Args>
 BufferInflowInjectionCK<ConditionType>::
@@ -221,7 +205,6 @@ template <typename... Args>
 BidirectionalBoundaryCK<ExecutionPolicy, KernelCorrectionType, ConditionType>::
     BidirectionalBoundaryCK(OrientedBoxByCell &oriented_box_part, Args &&...args)
     : AbstractBidirectionalBoundary(), tag_buffer_particles_(oriented_box_part),
-      reset_buffer_correction_matrix_(oriented_box_part),
       boundary_condition_(oriented_box_part, std::forward<Args>(args)...),
       inflow_injection_(oriented_box_part, std::forward<Args>(args)...),
       outflow_indication_(oriented_box_part) {}

--- a/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h
+++ b/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h
@@ -33,7 +33,7 @@
 
 #include "base_local_dynamics.h"
 #include "interaction_ck.h"
-#include "particle_functors.h"
+#include "particle_functors_ck.h"
 
 #include <tuple>
 
@@ -50,21 +50,7 @@ class LinearCorrectionMatrix<Base, RelationType<Parameters...>>
   public:
     template <class DynamicsIdentifier>
     explicit LinearCorrectionMatrix(DynamicsIdentifier &identifier);
-    virtual ~LinearCorrectionMatrix(){};
-
-    class InteractKernel
-        : public Interaction<RelationType<Parameters...>>::InteractKernel
-    {
-      public:
-        template <class ExecutionPolicy, typename... Args>
-        InteractKernel(const ExecutionPolicy &ex_policy,
-                       LinearCorrectionMatrix<Base, RelationType<Parameters...>> &encloser,
-                       Args &&...args);
-
-      protected:
-        Real *Vol_;
-        Matd *B_;
-    };
+    virtual ~LinearCorrectionMatrix() {};
 
   protected:
     DiscreteVariable<Matd> *dv_B_;
@@ -74,37 +60,37 @@ template <typename... Parameters>
 class LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>
     : public LinearCorrectionMatrix<Base, Inner<Parameters...>>
 {
+    using BaseInteraction = LinearCorrectionMatrix<Base, Inner<Parameters...>>;
 
   public:
     template <class DynamicsIdentifier>
-    explicit LinearCorrectionMatrix(DynamicsIdentifier &identifier, Real alpha = Real(0))
-        : LinearCorrectionMatrix<Base, Inner<Parameters...>>(identifier), alpha_(alpha){};
+    explicit LinearCorrectionMatrix(DynamicsIdentifier &identifier, Real alpha = Real(0));
     template <typename BodyRelationType, typename FirstArg>
-    explicit LinearCorrectionMatrix(DynamicsArgs<BodyRelationType, FirstArg> parameters)
-        : LinearCorrectionMatrix(parameters.identifier_, std::get<0>(parameters.others_)){};
-    virtual ~LinearCorrectionMatrix(){};
+    explicit LinearCorrectionMatrix(DynamicsArgs<BodyRelationType, FirstArg> parameters);
+    virtual ~LinearCorrectionMatrix() {};
 
-    class InteractKernel
-        : public LinearCorrectionMatrix<Base, Inner<Parameters...>>::InteractKernel
+    class InteractKernel : public BaseInteraction::InteractKernel
     {
       public:
-        template <class ExecutionPolicy>
-        InteractKernel(const ExecutionPolicy &ex_policy,
-                       LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>> &encloser);
+        template <class ExecutionPolicy, class EncloserType>
+        InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
         void interact(size_t index_i, Real dt = 0.0);
+
+      protected:
+        DataView<Matd> B_;
+        DataView<Real> Vol_;
     };
 
     class UpdateKernel
-        : public LinearCorrectionMatrix<Base, Inner<Parameters...>>::InteractKernel
     {
       public:
-        template <class ExecutionPolicy>
-        UpdateKernel(const ExecutionPolicy &ex_policy,
-                     LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>> &encloser);
+        template <class ExecutionPolicy, class EncloserType>
+        UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
         void update(size_t index_i, Real dt = 0.0);
 
       protected:
         Real alpha_;
+        DataView<Matd> B_;
     };
 
   protected:
@@ -116,33 +102,59 @@ template <typename... Parameters>
 class LinearCorrectionMatrix<Contact<Parameters...>>
     : public LinearCorrectionMatrix<Base, Contact<Parameters...>>
 {
+    using BaseInteraction = LinearCorrectionMatrix<Base, Contact<Parameters...>>;
+
   public:
     template <class DynamicsIdentifier>
     explicit LinearCorrectionMatrix(DynamicsIdentifier &identifier);
-    virtual ~LinearCorrectionMatrix(){};
+    virtual ~LinearCorrectionMatrix() {};
 
-    class InteractKernel
-        : public LinearCorrectionMatrix<Base, Contact<Parameters...>>::InteractKernel
+    class InteractKernel : public BaseInteraction::InteractKernel
     {
       public:
-        template <class ExecutionPolicy>
-        InteractKernel(const ExecutionPolicy &ex_policy,
-                       LinearCorrectionMatrix<Contact<Parameters...>> &encloser,
-                       size_t contact_index);
+        template <class ExecutionPolicy, class EncloserType>
+        InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, size_t contact_index);
         void interact(size_t index_i, Real dt = 0.0);
 
       protected:
-        Real *contact_Vol_k_;
+        DataView<Matd> B_;
+        DataView<Real> contact_Vol_k_;
     };
 };
-
 using LinearCorrectionMatrixComplex = LinearCorrectionMatrix<Inner<WithUpdate>, Contact<>>;
+
+template <class DynamicsIdentifier, class ParticleScope>
+class LinearCorrectionMatrixScope : public BaseLocalDynamics<DynamicsIdentifier>
+{
+    using ParticleScopeTypeKernel = typename ParticleScopeTypeCK<ParticleScope>::ComputingKernel;
+
+  public:
+    template <typename... Args>
+    explicit LinearCorrectionMatrixScope(DynamicsIdentifier &identifier, Args... args);
+    virtual ~LinearCorrectionMatrixScope() {}
+
+    class UpdateKernel
+    {
+      public:
+        template <class ExecutionPolicy, class EncloserType>
+        UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
+        void update(size_t index_i, Real dt = 0.0);
+
+      protected:
+        DataView<Matd> B_;
+        ParticleScopeTypeKernel within_scope_;
+    };
+
+  protected:
+    DiscreteVariable<Matd> *dv_B_;
+    ParticleScopeTypeCK<ParticleScope> within_scope_method_;
+};
 
 class NoKernelCorrectionCK : public KernelCorrection
 {
   public:
     typedef Real CorrectionDataType;
-    NoKernelCorrectionCK(BaseParticles *particles) : KernelCorrection(){};
+    NoKernelCorrectionCK(BaseParticles *particles) : KernelCorrection() {};
 
     class ComputingKernel : public ParameterFixed<Real>
     {
@@ -160,7 +172,7 @@ class LinearCorrectionCK : public KernelCorrection
     typedef Matd CorrectionDataType;
     LinearCorrectionCK(BaseParticles *particles)
         : KernelCorrection(),
-          dv_B_(particles->getVariableByName<Matd>("LinearCorrectionMatrix")){};
+          dv_B_(particles->getVariableByName<Matd>("LinearCorrectionMatrix")) {};
 
     class ComputingKernel : public ParameterVariable<Matd>
     {

--- a/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.hpp
+++ b/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.hpp
@@ -14,85 +14,104 @@ LinearCorrectionMatrix<Base, RelationType<Parameters...>>::
       dv_B_(this->particles_->template registerStateVariable<Matd>(
           "LinearCorrectionMatrix", IdentityMatrix<Matd>::value)) {}
 //=================================================================================================//
-template <template <typename...> class RelationType, typename... Parameters>
-template <class ExecutionPolicy, typename... Args>
-LinearCorrectionMatrix<Base, RelationType<Parameters...>>::InteractKernel::
-    InteractKernel(const ExecutionPolicy &ex_policy,
-                   LinearCorrectionMatrix<Base, RelationType<Parameters...>> &encloser,
-                   Args &&...args)
-    : Interaction<RelationType<Parameters...>>::
-          InteractKernel(ex_policy, encloser, std::forward<Args>(args)...),
-      Vol_(encloser.dv_Vol_->DelegatedData(ex_policy)),
-      B_(encloser.dv_B_->DelegatedData(ex_policy)) {}
+template <typename... Parameters>
+template <class DynamicsIdentifier>
+LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>::LinearCorrectionMatrix(
+    DynamicsIdentifier &identifier, Real alpha)
+    : BaseInteraction(identifier), alpha_(alpha) {}
 //=================================================================================================//
 template <typename... Parameters>
-template <class ExecutionPolicy>
+template <typename BodyRelationType, typename FirstArg>
+LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>::LinearCorrectionMatrix(
+    DynamicsArgs<BodyRelationType, FirstArg> parameters)
+    : LinearCorrectionMatrix(parameters.identifier_, std::get<0>(parameters.others_)) {}
+//=================================================================================================//
+template <typename... Parameters>
+template <class ExecutionPolicy, class EncloserType>
 LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>::InteractKernel::
-    InteractKernel(const ExecutionPolicy &ex_policy,
-                   LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>> &encloser)
-    : LinearCorrectionMatrix<Base, Inner<Parameters...>>::InteractKernel(ex_policy, encloser) {}
+    InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
+    : BaseInteraction::InteractKernel(ex_policy, encloser),
+      B_(encloser.dv_B_->DelegatedDataView(ex_policy)),
+      Vol_(encloser.dv_Vol_->DelegatedDataView(ex_policy)) {}
 //=================================================================================================//
 template <typename... Parameters>
 void LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>::
     InteractKernel::interact(size_t index_i, Real dt)
 {
-    Matd local_configuration = Matd::Zero();
+    B_[index_i] = Matd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
     {
         UnsignedInt index_j = this->neighbor_index_[n];
-        Vecd nablaW_ijV_j = this->nablaW_ij(index_i, index_j) * this->Vol_[index_j];
-        local_configuration -= this->vec_r_ij(index_i, index_j) * nablaW_ijV_j.transpose();
+        Vecd nablaW_ijV_j = this->nablaW_ij(index_i, index_j) * Vol_[index_j];
+        B_[index_i] -= this->vec_r_ij(index_i, index_j) * nablaW_ijV_j.transpose();
     }
-    this->B_[index_i] = local_configuration;
 }
 //=================================================================================================//
 template <typename... Parameters>
-template <class ExecutionPolicy>
+template <class ExecutionPolicy, class EncloserType>
 LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>::UpdateKernel::
-    UpdateKernel(const ExecutionPolicy &ex_policy,
-                 LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>> &encloser)
-    : LinearCorrectionMatrix<Base, Inner<Parameters...>>::InteractKernel(ex_policy, encloser),
-      alpha_(encloser.alpha_) {}
+    UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
+    : alpha_(encloser.alpha_), B_(encloser.dv_B_->DelegatedDataView(ex_policy)) {}
 //=================================================================================================//
 template <typename... Parameters>
 void LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>::
     UpdateKernel::update(size_t index_i, Real dt)
 {
-    Real determinant = this->B_[index_i].determinant();
+    Real determinant = B_[index_i].determinant();
     Real det_sqr = SMAX(alpha_ - determinant, Real(0));
-    Matd inverse = inverseTikhonov(this->B_[index_i], SqrtEps);
+    Matd inverse = inverseTikhonov(B_[index_i], SqrtEps);
     Real weight = determinant / (determinant + det_sqr);
-    this->B_[index_i] = weight * inverse + (1.0 - weight) * Matd::Identity();
+    B_[index_i] = weight * inverse + (1.0 - weight) * Matd::Identity();
 }
 //=================================================================================================//
 template <typename... Parameters>
 template <class DynamicsIdentifier>
-LinearCorrectionMatrix<Contact<Parameters...>>::
-    LinearCorrectionMatrix(DynamicsIdentifier &identifier)
-    : LinearCorrectionMatrix<Base, Contact<Parameters...>>(identifier) {}
+LinearCorrectionMatrix<Contact<Parameters...>>::LinearCorrectionMatrix(DynamicsIdentifier &identifier)
+    : BaseInteraction(identifier) {}
 //=================================================================================================//
 template <typename... Parameters>
-template <class ExecutionPolicy>
+template <class ExecutionPolicy, class EncloserType>
 LinearCorrectionMatrix<Contact<Parameters...>>::InteractKernel::
-    InteractKernel(const ExecutionPolicy &ex_policy,
-                   LinearCorrectionMatrix<Contact<Parameters...>> &encloser,
-                   size_t contact_index)
-    : LinearCorrectionMatrix<Base, Contact<Parameters...>>::
-          InteractKernel(ex_policy, encloser, contact_index),
-      contact_Vol_k_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)) {}
+    InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, size_t contact_index)
+    : BaseInteraction::InteractKernel(ex_policy, encloser, contact_index),
+      B_(encloser.dv_B_->DelegatedDataView(ex_policy)),
+      contact_Vol_k_(encloser.dv_contact_Vol_[contact_index]->DelegatedDataView(ex_policy)) {}
 //=================================================================================================//
 template <typename... Parameters>
 void LinearCorrectionMatrix<Contact<Parameters...>>::
     InteractKernel::interact(size_t index_i, Real dt)
 {
-    Matd local_configuration = Matd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
     {
         UnsignedInt index_j = this->neighbor_index_[n];
-        Vecd gradW_ij = this->dW_ij(index_i, index_j) * contact_Vol_k_[index_j] * this->e_ij(index_i, index_j);
-        local_configuration -= this->vec_r_ij(index_i, index_j) * gradW_ij.transpose();
+        Vecd nablaW_ijV_j = this->nablaW_ij(index_i, index_j) * contact_Vol_k_[index_j];
+        B_[index_i] -= this->vec_r_ij(index_i, index_j) * nablaW_ijV_j.transpose();
     }
-    this->B_[index_i] += local_configuration;
+}
+//=================================================================================================//
+template <class DynamicsIdentifier, class ParticleScope>
+template <typename... Args>
+LinearCorrectionMatrixScope<DynamicsIdentifier, ParticleScope>::
+    LinearCorrectionMatrixScope(DynamicsIdentifier &identifier, Args... args)
+    : BaseLocalDynamics<DynamicsIdentifier>(identifier),
+      dv_B_(this->particles_->template getVariableByName<Matd>("LinearCorrectionMatrix")),
+      within_scope_method_(this->particles_, args...) {}
+//=================================================================================================//
+template <class DynamicsIdentifier, class ParticleScope>
+template <class ExecutionPolicy, class EncloserType>
+LinearCorrectionMatrixScope<DynamicsIdentifier, ParticleScope>::UpdateKernel::
+    UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
+    : B_(encloser.dv_B_->DelegatedDataView(ex_policy)),
+      within_scope_(ex_policy, encloser.within_scope_method_) {}
+//=================================================================================================//
+template <class DynamicsIdentifier, class ParticleScope>
+void LinearCorrectionMatrixScope<DynamicsIdentifier, ParticleScope>::UpdateKernel::
+    update(size_t index_i, Real dt)
+{
+    if (!within_scope_(index_i))
+    {
+        B_[index_i] = Matd::Identity();
+    }
 }
 //=================================================================================================//
 } // namespace SPH

--- a/tests/test_simulation/test_3d_simulation/data/t_pipe.json
+++ b/tests/test_simulation/test_3d_simulation/data/t_pipe.json
@@ -139,6 +139,13 @@
     }
   ],
 
+  "extra_state_recording": [
+    {
+      "name": "BloodBody",
+      "variables": [{ "real_type": ["Pressure"] }]
+    }
+  ],
+
   "solver_parameters": {
     "end_time": 0.1,
     "output_interval": 0.01,


### PR DESCRIPTION
This pull request refactors and improves the handling of the linear correction matrix and related simulation hooks in the fluid simulation builder. The main changes include replacing the "AfterAdvectionStepSetup" hook point with "AfterLinearCorrectionMatrix", consolidating the setup and execution of the linear correction matrix into a new utility method, and removing obsolete code for buffer correction. These changes improve the clarity, extensibility, and maintainability of the simulation pipeline.

**Simulation pipeline and hook refactoring:**

* Replaced the `AfterAdvectionStepSetup` and `InitialAfterAdvectionStepSetup` hook points with `AfterLinearCorrectionMatrix` and `InitialAfterLinearCorrectionMatrix` in both `SimulationHookPoint` and `InitializationHookPoint` enums, and updated all corresponding hook insertions and executions to use the new names. [[1]](diffhunk://#diff-51f723eac8c19d64123ebfc316e649e98b9ee1679f5e3b915b415b9448cc0872L109-R109) [[2]](diffhunk://#diff-51f723eac8c19d64123ebfc316e649e98b9ee1679f5e3b915b415b9448cc0872L118-R118) [[3]](diffhunk://#diff-3921dfdf9ef04404364e723d34c65a9ed7107a76752bc65280a0a7391a93226eL165-R191) [[4]](diffhunk://#diff-3921dfdf9ef04404364e723d34c65a9ed7107a76752bc65280a0a7391a93226eL213-R239) [[5]](diffhunk://#diff-bf5ffe1c2a0d200331558aa97b99664ed9e99126ddd461e981c113094d5c48daL113-R122) [[6]](diffhunk://#diff-bf5ffe1c2a0d200331558aa97b99664ed9e99126ddd461e981c113094d5c48daL176-R185)

* Updated the simulation and initialization pipelines to execute the linear correction matrix step before the new hook points, ensuring a clearer and more logical ordering of simulation stages. [[1]](diffhunk://#diff-bf5ffe1c2a0d200331558aa97b99664ed9e99126ddd461e981c113094d5c48daL113-R122) [[2]](diffhunk://#diff-bf5ffe1c2a0d200331558aa97b99664ed9e99126ddd461e981c113094d5c48daL176-R185)

**Linear correction matrix improvements:**

* Introduced a new method `addLinearCorrectionMatrixWithScope` in `FluidSimulationBuilder` to encapsulate the setup of the linear correction matrix, including conditional addition of scope dynamics for open boundary cases. Updated the simulation builder to use this method. [[1]](diffhunk://#diff-3921dfdf9ef04404364e723d34c65a9ed7107a76752bc65280a0a7391a93226eR146-R166) [[2]](diffhunk://#diff-bf5ffe1c2a0d200331558aa97b99664ed9e99126ddd461e981c113094d5c48daL59-R67) [[3]](diffhunk://#diff-f6e93bf7979f2395c505fb0060585a664e41596a90ca53b463362322827e01fdR94-R98)

* Refactored the implementation of `LinearCorrectionMatrix` and its kernels for improved clarity, type safety, and maintainability, including changes to constructor signatures and data member handling. [[1]](diffhunk://#diff-29ba7591d18f697921e547aa40a096c7715514361487521b02a71d71058baedeL55-L68) [[2]](diffhunk://#diff-29ba7591d18f697921e547aa40a096c7715514361487521b02a71d71058baedeR63-R93)

**Code cleanup and obsolete code removal:**

* Removed the obsolete `ResetBufferCorrectionMatrixCK` class and all related code from the bidirectional boundary condition implementation, simplifying the codebase and eliminating unused logic. [[1]](diffhunk://#diff-544eb4809a9d6a2c3824f1d5c36c679857f219b3452ae78eef485184813b6170L20-L27) [[2]](diffhunk://#diff-bb97750a7b1a137a68343f15d005b3dccb09627b3806983f73c13c27c2ced0cdL71-L97) [[3]](diffhunk://#diff-bb97750a7b1a137a68343f15d005b3dccb09627b3806983f73c13c27c2ced0cdL306) [[4]](diffhunk://#diff-bb97750a7b1a137a68343f15d005b3dccb09627b3806983f73c13c27c2ced0cdL315-R295) [[5]](diffhunk://#diff-76627e42f88304d4e0ee0d7d8805a434507571dab4078bee97710e7fb68ac6c0L29-L44) [[6]](diffhunk://#diff-76627e42f88304d4e0ee0d7d8805a434507571dab4078bee97710e7fb68ac6c0L224)

* Updated include directives to use the correct header for particle functors.