### PR TITLE
add read 3 polygon types

### DIFF
--- a/sphinxsim/config/schemas.py
+++ b/sphinxsim/config/schemas.py
@@ -53,6 +53,9 @@ class MultiPolygonPrimitiveType(str, Enum):
     BOX = "box"
     BOUNDING_BOX = "bounding_box"
     CONTAINER_BOX = "container_box"
+    CIRCLE = "circle"
+    TRIANGLE = "triangle"
+    CLOCKWISE_POINTS = "clockwise_points"
     DATA_FILE = "data_file"
 
 
@@ -121,6 +124,10 @@ class MultiPolygonEntryConfig(BaseModel):
     type: MultiPolygonPrimitiveType
     half_size: Optional[List[float]] = Field(default=None, min_length=2, max_length=3)
     transform: Optional[TransformConfig] = None
+    center: Optional[List[float]] = Field(default=None, min_length=2, max_length=3)
+    radius: Optional[float] = Field(default=None, gt=0)
+    resolution: Optional[int] = Field(default=None, gt=0)
+    points: Optional[List[List[float]]] = None
     lower_bound: Optional[List[float]] = Field(default=None, min_length=2, max_length=3)
     upper_bound: Optional[List[float]] = Field(default=None, min_length=2, max_length=3)
     inner_lower_bound: Optional[List[float]] = Field(default=None, min_length=2, max_length=3)
@@ -145,6 +152,17 @@ class MultiPolygonEntryConfig(BaseModel):
                 )
             if len(self.inner_lower_bound) != len(self.inner_upper_bound):
                 raise ValueError("multipolygon container_box dimensionality must match")
+        elif self.type == MultiPolygonPrimitiveType.CIRCLE:
+            if self.center is None or self.radius is None or self.resolution is None:
+                raise ValueError("multipolygon circle requires center, radius and resolution")
+        elif self.type == MultiPolygonPrimitiveType.TRIANGLE:
+            if self.half_size is None or self.transform is None:
+                raise ValueError("multipolygon triangle requires half_size and transform")
+        elif self.type == MultiPolygonPrimitiveType.CLOCKWISE_POINTS:
+            if not self.points:
+                raise ValueError("multipolygon clockwise_points requires points")
+            if self.points[0] != self.points[-1]:
+                raise ValueError("multipolygon clockwise_points must repeat the first point as the last point")
         elif self.type == MultiPolygonPrimitiveType.DATA_FILE:
             if not self.file_path:
                 raise ValueError("multipolygon data_file requires file_path")

--- a/sphinxsim/sph_simulation/common_builder/geometry_builder.cpp
+++ b/sphinxsim/sph_simulation/common_builder/geometry_builder.cpp
@@ -119,10 +119,45 @@ MultiPolygon GeometryBuilder::parseMultiPolygon(const ScalingConfig &scaling_con
         return multi_polygon;
     }
 
+    if (polygon_type == "circle")
+    {
+        Vecd center = scaling_config.jsonToVecd(config.at("center"), "Length");
+        Real radius = scaling_config.jsonToReal(config.at("radius"), "Length");
+        int resolution = config.at("resolution").get<int>();
+        multi_polygon.addCircle(center, radius, resolution, GeometricOps::add);
+        return multi_polygon;
+    }
+
+    if (polygon_type == "triangle")
+    {
+        Transform transform = scaling_config.jsonToTransform(config.at("transform"));
+        Vecd half_size = scaling_config.jsonToVecd(config.at("half_size"), "Length");
+        multi_polygon.addTriangle(transform, half_size, GeometricOps::add);
+        return multi_polygon;
+    }
+
+    if (polygon_type == "clockwise_points")
+    {
+        std::vector<Vecd> points;
+        for (const auto &p : config.at("points"))
+        {
+            points.push_back(scaling_config.jsonToVecd(p, "Length"));
+        }
+
+        if ((points[0] - points.back()).norm() > Eps)
+        {
+            throw std::runtime_error(
+                "GeometryBuilder::parseMultiPolygon: the first and last of clockwise points must be the same!");
+        }
+        multi_polygon.addPolygon(points, GeometricOps::add);
+        return multi_polygon;
+    }
+
     if (polygon_type == "data_file")
     {
-        multi_polygon.addPolygonFromFile(config.at("file_path").get<std::string>(), GeometricOps::add,
-                                         Vecd::Zero(), 1.0 / scaling_config.getScalingRef("Length"));
+        multi_polygon.addPolygonFromFile(
+            config.at("file_path").get<std::string>(), GeometricOps::add,
+            Vecd::Zero(), 1.0 / scaling_config.getScalingRef("Length"));
         return multi_polygon;
     }
 

--- a/sphinxsim/sphinxsys/src/for_2D_build/geometries/multi_polygon_shape.cpp
+++ b/sphinxsim/sphinxsys/src/for_2D_build/geometries/multi_polygon_shape.cpp
@@ -129,7 +129,7 @@ void MultiPolygon::addBoostMultiPoly(boost_multi_poly &boost_multi_poly_op, Geom
     multi_poly_ = MultiPolygonByBooleanOps(multi_poly_, boost_multi_poly_op, op);
 }
 //=================================================================================================//
-void MultiPolygon::addBox(Transform transform, const Vecd &halfsize, GeometricOps op)
+void MultiPolygon::addBox(const Transform transform, const Vecd &halfsize, GeometricOps op)
 {
     Vecd point0 = transform.shiftFrameStationToBase(-halfsize);
     Vecd point1 = transform.shiftFrameStationToBase(Vecd(-halfsize[0], halfsize[1]));
@@ -223,6 +223,15 @@ void MultiPolygon::addPolygon(const std::vector<Vecd> &points, GeometricOps op)
     convert(poly, multi_poly_polygon);
 
     multi_poly_ = MultiPolygonByBooleanOps(multi_poly_, multi_poly_polygon, op);
+}
+//=================================================================================================//
+void MultiPolygon::addTriangle(const Transform &transform, const Vecd &half_size, GeometricOps op)
+{
+    Vecd point0 = transform.shiftFrameStationToBase(Vecd(half_size[0], -half_size[1]));
+    Vecd point1 = transform.shiftFrameStationToBase(Vecd(-half_size[0], -half_size[1]));
+    Vecd point2 = transform.shiftFrameStationToBase(Vecd(0.0, half_size[1]));
+    std::vector<Vecd> points = {point0, point1, point2, point0};
+    addPolygon(points, op);
 }
 //=================================================================================================//
 void MultiPolygon::

--- a/sphinxsim/sphinxsys/src/for_2D_build/geometries/multi_polygon_shape.h
+++ b/sphinxsim/sphinxsys/src/for_2D_build/geometries/multi_polygon_shape.h
@@ -94,10 +94,11 @@ class MultiPolygon
     void addMultiPolygon(const MultiPolygon &multi_polygon, GeometricOps op);
     void addBoostMultiPoly(boost_multi_poly &boost_multi_poly, GeometricOps op);
     void addPolygon(const std::vector<Vecd> &points, GeometricOps op);
-    void addBox(Transform transform, const Vecd &halfsize, GeometricOps op);
+    void addBox(const Transform transform, const Vecd &halfsize, GeometricOps op);
     void addBox(const BoundingBox2d &bounding_box, GeometricOps op);
     void addContainerBox(const BoundingBox2d &bounding_box, Real thickness, GeometricOps op);
     void addCircle(const Vecd &center, Real radius, int resolution, GeometricOps op);
+    void addTriangle(const Transform &transform, const Vecd &half_size, GeometricOps op);
     void addPolygonFromFile(std::string file_path_name, GeometricOps op, Vecd translation = Vecd::Zero(), Real scale_factor = 1.0);
 
   protected:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -260,6 +260,64 @@ class TestSimulationConfig:
         cfg = _make_minimal_fluid_config(geometries=geometries)
         assert any(shape.name == "ExpandedWaterBody" for shape in cfg.geometries.shapes)
 
+    def test_multipolygon_accepts_new_polygon_types(self):
+        geometries = {
+            "system_domain": {"lower_bound": [0.0, 0.0], "upper_bound": [1.0, 1.0]},
+            "global_resolution": {"particle_spacing": 0.05},
+            "shapes": [
+                {
+                    "name": "WaterBody",
+                    "type": "multipolygon",
+                    "polygons": [
+                        {
+                            "operation": "union",
+                            "type": "circle",
+                            "center": [0.2, 0.2],
+                            "radius": 0.1,
+                            "resolution": 24,
+                        },
+                        {
+                            "operation": "union",
+                            "type": "triangle",
+                            "half_size": [0.1, 0.05],
+                            "transform": {
+                                "translation": [0.35, 0.25],
+                                "rotation_angle": 0.0,
+                            },
+                        },
+                        {
+                            "operation": "union",
+                            "type": "clockwise_points",
+                            "points": [[0.6, 0.6], [0.8, 0.6], [0.8, 0.8], [0.6, 0.6]],
+                        },
+                    ],
+                },
+                {
+                    "name": "WallBoundary",
+                    "type": "bounding_box",
+                    "lower_bound": [0.0, 0.0],
+                    "upper_bound": [1.0, 1.0],
+                },
+            ],
+            "oriented_boxes": [
+                {
+                    "name": "Inlet",
+                    "type": "region",
+                    "half_size": [0.1, 0.05],
+                    "transform": {"translation": [0.05, 0.2], "rotation_angle": 0.0},
+                }
+            ],
+        }
+
+        cfg = _make_minimal_fluid_config(geometries=geometries)
+        multipolygon = cfg.geometries.shapes[0]
+        assert multipolygon.type.value == "multipolygon"
+        assert [polygon.type.value for polygon in multipolygon.polygons] == [
+            "circle",
+            "triangle",
+            "clockwise_points",
+        ]
+
     def test_shape_duplicate_name_rejected(self):
         geometries = {
             "system_domain": {"lower_bound": [0.0, 0.0], "upper_bound": [1.0, 1.0]},


### PR DESCRIPTION
This pull request adds support for new polygon types—`circle`, `triangle`, and `clockwise_points`—to the multipolygon geometry system, including schema, validation, geometry-building logic, and comprehensive tests. These changes enable more flexible and expressive geometric configurations in both configuration files and the underlying simulation code.

**Schema and Validation Enhancements:**

- Added new polygon types (`circle`, `triangle`, `clockwise_points`) to the `MultiPolygonPrimitiveType` enum and updated the `MultiPolygonEntryConfig` schema to support their required parameters (`center`, `radius`, `resolution`, `points`). Validation logic was extended to ensure correct parameter presence and structure for each new type. [[1]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289R56-R58) [[2]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289R127-R130) [[3]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289R155-R165)

**Geometry Builder and Shape Implementation:**

- Implemented parsing and construction logic for the new polygon types in the geometry builder (`parseMultiPolygon`), including methods to add circles, triangles, and polygons defined by clockwise points. [[1]](diffhunk://#diff-a919ad3f389fa0aea84a720124a1777080bf1fa2c2cc182bc04f25a1c5702331R122-R159) [[2]](diffhunk://#diff-19f9100d2accb606b057e298adc25eb2348eb912a1c5b3ff38223e95ebf64158R228-R236) [[3]](diffhunk://#diff-ce5f5f116b6b3f87f9adeadfdf087628f30f9665135593f76f71b7b0ca8c5b6bL97-R101)
- Added a new method `addTriangle` to the `MultiPolygon` class for triangle construction, and made a minor signature adjustment to `addBox` for consistency. [[1]](diffhunk://#diff-19f9100d2accb606b057e298adc25eb2348eb912a1c5b3ff38223e95ebf64158L132-R132) [[2]](diffhunk://#diff-19f9100d2accb606b057e298adc25eb2348eb912a1c5b3ff38223e95ebf64158R228-R236) [[3]](diffhunk://#diff-ce5f5f116b6b3f87f9adeadfdf087628f30f9665135593f76f71b7b0ca8c5b6bL97-R101)

**Testing:**

- Added a new test to verify that the multipolygon configuration correctly accepts and processes the new polygon types, ensuring end-to-end support from configuration to geometry creation.