### PR TITLE
make python runs from where jason is located

### DIFF
--- a/sphinxsim/bindings/sphinxsys_python.cpp
+++ b/sphinxsim/bindings/sphinxsys_python.cpp
@@ -69,7 +69,7 @@ PYBIND11_MODULE(MODULE_NAME, m)
     py::class_<GeometryBuilder>(m, "GeometryBuilder")
         .def(py::init<const std::filesystem::path &>(), py::arg("config_path"),
              "Initialize GeometryBuilder with path to JSON config file")
-        .def("resetOutputRoot", &GeometryBuilder::resetOutputRoot, py::arg("output_root"),
+        .def("resetInOutputRoot", &GeometryBuilder::resetInOutputRoot, py::arg("output_root"),
              "Override output/restart/reload root folder. Call before building geometries.")
         .def("buildGeometries", &GeometryBuilder::buildGeometries,
              "Build geometries from JSON configuration file");

--- a/sphinxsim/config/schemas.py
+++ b/sphinxsim/config/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, AliasChoices, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class SimulationType(str, Enum):
@@ -133,7 +133,7 @@ class MultiPolygonEntryConfig(BaseModel):
     inner_lower_bound: Optional[List[float]] = Field(default=None, min_length=2, max_length=3)
     inner_upper_bound: Optional[List[float]] = Field(default=None, min_length=2, max_length=3)
     thickness: Optional[float] = Field(default=None, gt=0)
-    file_name: Optional[str] = Field(default=None, validation_alias=AliasChoices("file_name", "file_path"))
+    file_name: Optional[str] = None
 
     @model_validator(mode="after")
     def _validate_shape_payload(self) -> "MultiPolygonEntryConfig":
@@ -187,7 +187,7 @@ class ShapeConfig(BaseModel):
 
     polygons: Optional[List[MultiPolygonEntryConfig]] = None
 
-    file_name: Optional[str] = Field(default=None, validation_alias=AliasChoices("file_name", "file_path"))
+    file_name: Optional[str] = None
     translation: Optional[List[float]] = Field(default=None, min_length=3, max_length=3)
     scale: Optional[float] = Field(default=None, gt=0)
 

--- a/sphinxsim/config/schemas.py
+++ b/sphinxsim/config/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, AliasChoices, model_validator
 
 
 class SimulationType(str, Enum):
@@ -133,7 +133,7 @@ class MultiPolygonEntryConfig(BaseModel):
     inner_lower_bound: Optional[List[float]] = Field(default=None, min_length=2, max_length=3)
     inner_upper_bound: Optional[List[float]] = Field(default=None, min_length=2, max_length=3)
     thickness: Optional[float] = Field(default=None, gt=0)
-    file_path: Optional[str] = None
+    file_name: Optional[str] = Field(default=None, validation_alias=AliasChoices("file_name", "file_path"))
 
     @model_validator(mode="after")
     def _validate_shape_payload(self) -> "MultiPolygonEntryConfig":
@@ -164,8 +164,8 @@ class MultiPolygonEntryConfig(BaseModel):
             if self.points[0] != self.points[-1]:
                 raise ValueError("multipolygon clockwise_points must repeat the first point as the last point")
         elif self.type == MultiPolygonPrimitiveType.DATA_FILE:
-            if not self.file_path:
-                raise ValueError("multipolygon data_file requires file_path")
+            if not self.file_name:
+                raise ValueError("multipolygon data_file requires file_name")
         return self
 
 
@@ -187,7 +187,7 @@ class ShapeConfig(BaseModel):
 
     polygons: Optional[List[MultiPolygonEntryConfig]] = None
 
-    file_path: Optional[str] = None
+    file_name: Optional[str] = Field(default=None, validation_alias=AliasChoices("file_name", "file_path"))
     translation: Optional[List[float]] = Field(default=None, min_length=3, max_length=3)
     scale: Optional[float] = Field(default=None, gt=0)
 
@@ -225,8 +225,8 @@ class ShapeConfig(BaseModel):
             return self
 
         if self.type == BodyShapeType.TRIANGLE_MESH:
-            if not self.file_path:
-                raise ValueError("triangle_mesh shape requires file_path")
+            if not self.file_name:
+                raise ValueError("triangle_mesh shape requires file_name")
             return self
 
         return self

--- a/sphinxsim/sph_simulation/common_builder/geometry_builder.cpp
+++ b/sphinxsim/sph_simulation/common_builder/geometry_builder.cpp
@@ -11,7 +11,7 @@ GeometryBuilder::GeometryBuilder(const fs::path &config_path)
 //=================================================================================================//
 GeometryBuilder::~GeometryBuilder() = default;
 //=================================================================================================//
-void GeometryBuilder::resetOutputRoot(const fs::path &output_root)
+void GeometryBuilder::resetInOutputRoot(const fs::path &output_root)
 {
     IOEnvironment &io_env = IO::getEnvironment();
     if (!fs::exists(output_root))
@@ -19,6 +19,7 @@ void GeometryBuilder::resetOutputRoot(const fs::path &output_root)
         fs::create_directories(output_root);
     }
     io_env.resetOutputFolder((output_root / "output").string(), true);
+    io_env.resetInputFolder((config_path_.parent_path()).string(), true);
 }
 //=================================================================================================//
 void GeometryBuilder::buildGeometries()
@@ -195,7 +196,7 @@ MultiPolygon GeometryBuilder::parseMultiPolygon(const ScalingConfig &scaling_con
     if (polygon_type == "data_file")
     {
         multi_polygon.addPolygonFromFile(
-            config.at("file_path").get<std::string>(), GeometricOps::add,
+            config.at("file_name").get<std::string>(), GeometricOps::add,
             Vecd::Zero(), 1.0 / scaling_config.getScalingRef("Length"));
         return multi_polygon;
     }
@@ -296,7 +297,7 @@ Shape *GeometryBuilder::addShape(
 
         scale /= scaling_factor;
         TriangleMeshShapeSTL *shape = config_manager.emplaceEntity<TriangleMeshShapeSTL>(
-            name, config.at("file_path").get<std::string>(), translation, scale, name);
+            name, config.at("file_name").get<std::string>(), translation, scale, name);
         shape->writTriangleMeshShapeToVtp(Transform(), scaling_factor);
         return shape;
     }

--- a/sphinxsim/sph_simulation/common_builder/geometry_builder.h
+++ b/sphinxsim/sph_simulation/common_builder/geometry_builder.h
@@ -51,7 +51,7 @@ class GeometryBuilder
   public:
     GeometryBuilder(const fs::path &config_path);
     ~GeometryBuilder();
-    void resetOutputRoot(const fs::path &output_root);
+    void resetInOutputRoot(const fs::path &output_root);
     void buildGeometries();
     //----------------------------------------------------------------------
     // static functions for geometry construction used in simulation builder

--- a/sphinxsim/sphinxsys/src/shared/io_system/io_environment.cpp
+++ b/sphinxsim/sphinxsys/src/shared/io_system/io_environment.cpp
@@ -111,6 +111,20 @@ void IOEnvironment::resetReloadFolder(const std::string &new_name, bool keep_exi
         fs::create_directory(reload_folder_);
     }
 }
+//=================================================================================================//
+void IOEnvironment::resetInputFolder(const std::string &new_name, bool keep_existing)
+{
+    if (fs::exists(input_folder_) && !keep_existing)
+    {
+        fs::remove_all(input_folder_);
+    }
+
+    input_folder_ = new_name;
+    if (!fs::exists(input_folder_))
+    {
+        fs::create_directory(input_folder_);
+    }
+}
 //=============================================================================================//
 ParameterizationIO *IOEnvironment::defineParameterizationIO()
 {

--- a/sphinxsim/sphinxsys/src/shared/io_system/io_environment.h
+++ b/sphinxsim/sphinxsys/src/shared/io_system/io_environment.h
@@ -64,7 +64,10 @@ class IOEnvironment
     void resetOutputFolder(const std::string &new_name, bool keep_existing = false);
     void resetRestartFolder(const std::string &new_name, bool keep_existing = false);
     void resetReloadFolder(const std::string &new_name, bool keep_existing = false);
+    void resetInputFolder(const std::string &new_name, bool keep_existing = false);
     void reinitializeReloadFolder();
+
+
     std::string InputFolder() const { return input_folder_; }
     std::string OutputFolder() const { return output_folder_; }
     std::string RestartFolder() const { return restart_folder_; }

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -372,10 +372,10 @@ class ConfigVisualizer:
         original_dir = os.getcwd()
         # Change to the config file's directory so that relative paths in the
         # JSON (e.g. STL file_path for 3-D triangle_mesh shapes) resolve correctly.
-        os.chdir(self.config_path.parent.parent)
+        os.chdir(self.config_path.parent)
         try:
             builder = sph.GeometryBuilder(str(self.config_path))
-            builder.resetOutputRoot(str(vtp_output_dir))
+            builder.resetInOutputRoot(str(vtp_output_dir))
             builder.buildGeometries()
             self._bounds_sim = None
             self._shape_bounds_cache = None

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -318,6 +318,96 @@ class TestSimulationConfig:
             "clockwise_points",
         ]
 
+    def test_multipolygon_data_file_uses_file_name(self):
+        geometries = {
+            "system_domain": {"lower_bound": [0.0, 0.0], "upper_bound": [1.0, 1.0]},
+            "global_resolution": {"particle_spacing": 0.05},
+            "shapes": [
+                {
+                    "name": "WaterBody",
+                    "type": "multipolygon",
+                    "polygons": [
+                        {
+                            "operation": "union",
+                            "type": "data_file",
+                            "file_name": "water.dat",
+                        }
+                    ],
+                },
+                {
+                    "name": "WallBoundary",
+                    "type": "bounding_box",
+                    "lower_bound": [0.0, 0.0],
+                    "upper_bound": [1.0, 1.0],
+                },
+            ],
+            "oriented_boxes": [
+                {
+                    "name": "Inlet",
+                    "type": "region",
+                    "half_size": [0.1, 0.05],
+                    "transform": {"translation": [0.05, 0.2], "rotation_angle": 0.0},
+                }
+            ],
+        }
+
+        cfg = _make_minimal_fluid_config(geometries=geometries)
+        data_file = cfg.geometries.shapes[0].polygons[0]
+        assert data_file.type.value == "data_file"
+        assert data_file.file_name == "water.dat"
+
+    def test_triangle_mesh_uses_file_name(self):
+        geometries = {
+            "system_domain": {"lower_bound": [0.0, 0.0, 0.0], "upper_bound": [1.0, 1.0, 1.0]},
+            "global_resolution": {"particle_spacing": 0.05},
+            "shapes": [
+                {
+                    "name": "TetraBody",
+                    "type": "triangle_mesh",
+                    "file_name": "tetra.stl",
+                },
+                {
+                    "name": "WallBoundary",
+                    "type": "bounding_box",
+                    "lower_bound": [0.0, 0.0, 0.0],
+                    "upper_bound": [1.0, 1.0, 1.0],
+                },
+            ],
+        }
+
+        continuum_bodies = [
+            {
+                "name": "TetraBody",
+                "material": {
+                    "type": "general_continuum",
+                    "density": 1000.0,
+                    "sound_speed": 20.0,
+                    "youngs_modulus": 1.0e6,
+                    "poisson_ratio": 0.3,
+                },
+            }
+        ]
+
+        particle_generation = {
+            "build_and_run": False,
+            "settings": {
+                "bodies": [
+                    {"name": "TetraBody"},
+                    {"name": "WallBoundary", "solid_body": {}},
+                ],
+                "relaxation_parameters": {"total_iterations": 1000},
+            },
+        }
+
+        cfg = _make_minimal_continuum_config(
+            geometries=geometries,
+            continuum_bodies=continuum_bodies,
+            particle_generation=particle_generation,
+        )
+        triangle_mesh = cfg.geometries.shapes[0]
+        assert triangle_mesh.type.value == "triangle_mesh"
+        assert triangle_mesh.file_name == "tetra.stl"
+
     def test_shape_duplicate_name_rejected(self):
         geometries = {
             "system_domain": {"lower_bound": [0.0, 0.0], "upper_bound": [1.0, 1.0]},

--- a/tests/test_simulation/test_2d_simulation/data/milling.json
+++ b/tests/test_simulation/test_2d_simulation/data/milling.json
@@ -22,7 +22,7 @@
           {
             "operation": "union",
             "type": "data_file",
-            "file_path": "milling_tool.dat"
+            "file_name": "milling_tool.dat"
           }
         ]
       }

--- a/tests/test_simulation/test_3d_simulation/data/t_pipe.json
+++ b/tests/test_simulation/test_3d_simulation/data/t_pipe.json
@@ -25,13 +25,13 @@
       {
         "name": "BloodBody",
         "type": "triangle_mesh",
-        "file_path": "blood.stl",
+        "file_name": "blood.stl",
         "scale": 0.001
       },
       {
         "name": "WallBoundary",
         "type": "triangle_mesh",
-        "file_path": "t_pipe.stl",
+        "file_name": "t_pipe.stl",
         "scale": 0.001
       }
     ],


### PR DESCRIPTION
This pull request standardizes the configuration schema and codebase by replacing the use of `file_path` with `file_name` for shape and multipolygon data file references. It also introduces improved handling of input/output directories in geometry building, and updates tests and documentation accordingly. These changes enhance consistency, clarity, and maintainability across the codebase.

**Schema and Configuration Standardization:**

* Replaced `file_path` with `file_name` in the `MultiPolygonEntryConfig` and `ShapeConfig` classes, and updated all validation logic to require `file_name` instead of `file_path` for relevant shape types. [[1]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289L136-R136) [[2]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289L167-R168) [[3]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289L190-R190) [[4]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289L228-R229)
* Updated all usages in the geometry builder logic to reference `file_name` instead of `file_path` when loading files for multipolygon and triangle mesh shapes. [[1]](diffhunk://#diff-a919ad3f389fa0aea84a720124a1777080bf1fa2c2cc182bc04f25a1c5702331L198-R199) [[2]](diffhunk://#diff-a919ad3f389fa0aea84a720124a1777080bf1fa2c2cc182bc04f25a1c5702331L299-R300)

**Geometry Builder and IO Improvements:**

* Renamed the `resetOutputRoot` method in `GeometryBuilder` to `resetInOutputRoot`, and enhanced it to also set the input folder based on the config path, improving directory management for geometry building. [[1]](diffhunk://#diff-e732796e6b2f59f793070d01b3df918bf3aacf3dbdea409ed5a2bf36beac10aeL72-R72) [[2]](diffhunk://#diff-fac39f1a2d732712f71a0e759309e2b7ea0cd09ee170f57ca8ccd0ed18095017L54-R54) [[3]](diffhunk://#diff-a919ad3f389fa0aea84a720124a1777080bf1fa2c2cc182bc04f25a1c5702331L14-R22)
* Added a new `resetInputFolder` method to the `IOEnvironment` class to allow explicit control over the input directory, and updated related code to use this method. [[1]](diffhunk://#diff-def1d2bf305ee55927fb08ce1767d8412bf72e3692814879325e8f177d5dd7faR114-R127) [[2]](diffhunk://#diff-8833a344082215f5da89a6d2feff81579f59903dff6d8cfcbe06d3de2e671b84R67-R70)
* Fixed the working directory logic in the visualization preview to ensure relative paths in configuration files are resolved correctly.

**Testing and Documentation:**

* Updated and added new tests to verify that `file_name` is correctly used and validated for both multipolygon data files and triangle mesh shapes.
* Updated example simulation configuration files to use `file_name` instead of `file_path`. [[1]](diffhunk://#diff-b257e3c982fd3e83ccba1c9981592a4804223f2c93aecd80ffe58a5170843f64L25-R25) [[2]](diffhunk://#diff-61e4a1739305a42d30da9229ca0f34be53dee2d8ad33bf1b9a957547d6398f15L28-R34)