### PR TITLE
Xiangyu/improve visiualization

### DIFF
--- a/.github/skills/visualization_framework/SKILL.md
+++ b/.github/skills/visualization_framework/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: visualization-framework
+description: "SPHinXsim visualization framework guidance for preview architecture, rendering modes, annotations, constraints, and testing patterns. Invoke by default for any task that edits or debugs files under sphinxsim/visualization."
+---
+
+# SPHinXsim Visualization Framework
+
+## Purpose
+Use this skill when working on preview and rendering behavior in SPHinXsim, especially under `sphinxsim/visualization`.
+
+## Invocation Triggers
+Invoke this skill by default when any of the following is true:
+- The task modifies any file under `sphinxsim/visualization`.
+- The task debugs preview behavior, plotting behavior, camera/view mode, labels, or legend content.
+- The task touches visualization tests in `tests/test_visualization.py`.
+
+Do not skip this skill for visualization-path changes, even if the user request is brief.
+
+## Scope
+Covers:
+- Rendering pipeline and fallback behavior
+- `ConfigVisualizer` rendering flow
+- Annotation/label conventions
+- Body constraints and observer visualization
+- 2D vs 3D preview behavior
+- Visualization testing patterns
+
+Does not cover:
+- General C++ solver runtime debugging unrelated to preview
+- New project scaffolding
+- Non-visualization CLI features
+
+## Architecture
+
+### Rendering pipeline (priority order)
+1. VTP mode (preferred)
+- C++ `buildGeometries()` generates `.vtp` polygon meshes.
+- PyVista loads meshes for rendering.
+- Preferred for geometry fidelity.
+
+2. C++ bounds fallback
+- If VTP meshes are unavailable, query bounds from C++ simulation object.
+- Render bounding boxes as fallback.
+
+Design rule:
+- Prefer VTP/VTK objects for visualization.
+- Avoid constructing ad-hoc meshes from config-only geometry when VTP/VTK path is expected.
+
+## Core files
+- `sphinxsim/visualization/preview.py`
+- `sphinxsim/visualization/annotations.py`
+- `tests/test_visualization.py`
+
+## Key conventions
+
+### `ConfigVisualizer` responsibilities
+- Resolve spatial dimension / view mode.
+- Populate plotter with shapes, oriented boxes, constraints, observers, and annotations.
+- Keep rendering robust when PyVista or mesh assets are unavailable.
+
+### Annotation functions
+Keep annotation formatting centralized in `annotations.py`:
+- `body_label(...)`
+- `oriented_box_label(...)`
+- `observer_label(...)`
+- `body_constraint_label(...)`
+- `gravity_label(...)`
+
+Guidelines:
+- Use compact, readable multiline labels.
+- Keep display fields stable to avoid test churn.
+
+### Color palette
+Use fixed semantic color constants in `preview.py` for element classes (fluid, solid, continuum, region, observer, constraint, etc.).
+
+## Body constraints rendering pattern
+For each `config.body_constraints` item:
+- Build label with `body_constraint_label(...)`.
+- If constraint has a valid `region` referencing an oriented box:
+  - render region overlay (wireframe style, constraint color).
+  - place label at overlay center.
+- Else:
+  - resolve target body shape by name.
+  - place label at body mesh center when mesh is available.
+
+## 2D rendering notes
+- 2D mode should use orthographic XY-style view behavior.
+- Keep controls and camera defaults consistent with dimension inference.
+- Ensure labels and overlays remain legible in planar mode.
+
+## Testing playbook
+Use `tests/test_visualization.py`.
+
+1. Label unit tests
+- Validate generated text content for each annotation function.
+- Prefer strict substring assertions for critical fields.
+
+2. Preview rendering tests
+- Use mocked PyVista objects and fake plotter methods.
+- Assert rendering flow does not raise.
+- Assert expected plotting calls when behavior is deterministic.
+
+3. Config validation-aware fixtures
+- Build test config via `SimulationConfig(**data)`.
+- Respect schema requirements:
+  - region oriented box requires `half_size` and `transform`.
+  - simbody constraints require `solver_parameters.restart`.
+
+## Common failure patterns
+- Missing import in local `annotations` import block inside `_populate_plotter`.
+- Invalid oriented box schema in tests (`center/normal/radius` used for region type).
+- Simbody test configs missing restart section.
+- Mismatch between expected label text and annotation formatter.
+
+## Implementation checklist
+When adding a new visualization element:
+1. Add or extend schema model/validation if needed.
+2. Add annotation helper in `annotations.py`.
+3. Add render block in `_populate_plotter` with semantic color constant.
+4. Update legend entries.
+5. Add label tests and preview tests.
+6. Run visualization test file.
+
+## Verification command
+From repo root:
+
+```bash
+.venv/bin/python -m pytest tests/test_visualization.py -v
+```

--- a/.github/skills/visualization_framework/SKILL.md
+++ b/.github/skills/visualization_framework/SKILL.md
@@ -57,6 +57,7 @@ Design rule:
 - Resolve spatial dimension / view mode.
 - Populate plotter with shapes, oriented boxes, constraints, observers, and annotations.
 - Keep rendering robust when PyVista or mesh assets are unavailable.
+- Support screenshot output via `screenshot_path` parameter on `preview()`.
 
 ### Annotation functions
 Keep annotation formatting centralized in `annotations.py`:
@@ -88,6 +89,15 @@ For each `config.body_constraints` item:
 - Keep controls and camera defaults consistent with dimension inference.
 - Ensure labels and overlays remain legible in planar mode.
 
+## Screenshot output
+`preview()` accepts an optional `screenshot_path` parameter:
+- When provided, forces off-screen rendering (`off_screen = True`).
+- Calls `plotter.screenshot(str(screenshot_path))` instead of `plotter.show()`.
+- No interactive window is opened.
+- CLI exposes this via `--screenshot FILE` / `-s FILE` on both direct and shell `preview` commands.
+- Shell mode parses `--screenshot`/`-s` from the input line and passes it through `argparse.Namespace` to `cmd_preview`.
+- On success, CLI prints `📸 Screenshot saved to: {path}`.
+
 ## Testing playbook
 Use `tests/test_visualization.py`.
 
@@ -100,7 +110,15 @@ Use `tests/test_visualization.py`.
 - Assert rendering flow does not raise.
 - Assert expected plotting calls when behavior is deterministic.
 
-3. Config validation-aware fixtures
+3. Screenshot tests
+- Mock plotter must expose `screenshot()` method and `window_size` attribute.
+- Use `__getattr__` fallback on mock plotter to absorb arbitrary method calls (e.g. `add_axes`, `show_grid`, `add_radio_button_widget`).
+- Assert `plotter.screenshot()` is called when `screenshot_path` is set, and `plotter.show()` is called otherwise.
+- Assert `off_screen` is forced on when `screenshot_path` is provided.
+- CLI tests should verify `--screenshot`/`-s` flag passes the path through `argparse.Namespace`.
+- Shell tests should verify `--screenshot`/`-s` parsing from the input line.
+
+4. Config validation-aware fixtures
 - Build test config via `SimulationConfig(**data)`.
 - Respect schema requirements:
   - region oriented box requires `half_size` and `transform`.
@@ -111,6 +129,8 @@ Use `tests/test_visualization.py`.
 - Invalid oriented box schema in tests (`center/normal/radius` used for region type).
 - Simbody test configs missing restart section.
 - Mismatch between expected label text and annotation formatter.
+- Mock plotter missing methods called by `preview()` (e.g. `add_axes`, `show_grid`, `add_radio_button_widget`). Use `__getattr__` fallback returning a no-op lambda to avoid whack-a-mole.
+- Mock plotter missing `window_size` attribute — this is a property access, not a method call, so `__getattr__` won't catch it. Set it as a class attribute.
 
 ## Implementation checklist
 When adding a new visualization element:
@@ -120,6 +140,15 @@ When adding a new visualization element:
 4. Update legend entries.
 5. Add label tests and preview tests.
 6. Run visualization test file.
+
+When adding output modes (e.g. screenshot, animation):
+1. Add parameter to `preview()` method.
+2. Wire CLI flag in `cmd_preview()` (direct command subparser).
+3. Wire shell-mode parsing in the shell `preview` handler.
+4. Update mock plotter classes in tests with `__getattr__` fallback and any needed class attributes.
+5. Add tests for the new output path.
+6. Update `docs/visualization.md` and `docs/cli-usage.md`.
+7. Run visualization test file.
 
 ## Verification command
 From repo root:

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -78,6 +78,7 @@ Inside the shell, you can use the following commands:
 | `validate` | Reload the loaded file from disk and validate it |
 | `preview` | Render an interactive geometry/BC preview of the loaded config |
 | `preview --no-cpp` | Preview using schema bounding-box fallback only (no C++ build) |
+| `preview --screenshot FILE` | Save a screenshot to FILE instead of opening an interactive window |
 | `run` | Build and execute the loaded config |
 | `lock-geometry` | Lock geometry updates for the active shell session |
 | `unlock-geometry` | Unlock geometry updates (and reset downstream simulator state when attached) |
@@ -197,6 +198,7 @@ Options:
 | --- | --- |
 | `--no-cpp` | Skip C++ geometry build; render only the system domain bounding box and annotations |
 | `--off-screen` | Render off-screen (no window) — useful for automated testing |
+| `--screenshot FILE` / `-s FILE` | Save a screenshot to FILE instead of opening a window. Implies `--off-screen`. |
 
 Requires the optional `[visualization]` extra:
 
@@ -262,6 +264,7 @@ sphinxsim shell
 > validate
 > preview                   # inspect geometry and BCs interactively
 > preview --no-cpp          # quick bounding-box fallback if C++ not built
+> preview --screenshot preview.png   # save a screenshot for a report
 > run
 > exit
 ```

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -66,6 +66,31 @@ sphinxsim preview path/to/config.json --off-screen
 Renders to an off-screen buffer instead of opening a window.  Intended for
 automated testing or headless environments.
 
+### Screenshot output
+
+```bash
+sphinxsim preview path/to/config.json --screenshot preview.png
+# or equivalently:
+sphinxsim preview path/to/config.json -s preview.png
+```
+
+Saves a screenshot of the preview to the specified file instead of opening an
+interactive window.  This automatically enables off-screen rendering, so
+`--off-screen` is implied and does not need to be passed separately.
+
+Supported formats depend on your PyVista/VTK build, but typically include PNG,
+JPEG, and TIFF.
+
+```bash
+sphinxsim preview path/to/config.json -s preview.png
+📸 Screenshot saved to: preview.png
+```
+
+This is useful for:
+- Generating preview images for reports or documentation.
+- Batch-generating previews in CI pipelines.
+- Headless environments where no display is available.
+
 ### Interactive shell
 
 `preview` is available as a first-class shell command:
@@ -83,6 +108,12 @@ sphinxsim> preview --no-cpp
 🖼  Building configuration preview for: .../config.json
    Skipping C++ geometry build (--no-cpp).
 ℹ️ Preview rendered without C++ geometry (--no-cpp).
+
+sphinxsim> preview --screenshot preview.png
+🖼  Building configuration preview for: .../config.json
+   Attempting C++ geometry build for accurate VTP meshes...
+✅ Preview used C++ geometry (VTP meshes).
+📸 Screenshot saved to: preview.png
 ```
 
 `preview` requires a config to be loaded first (via `load` or `generate`).
@@ -102,6 +133,7 @@ viz = ConfigVisualizer(config, project_root=Path("."), config_path=config_path)
 viz.preview()                     # opens interactive window
 viz.preview(use_cpp=False)        # skip C++ build (shapes not rendered)
 viz.preview(title="My setup")     # custom window title
+viz.preview(screenshot_path="preview.png")  # save screenshot, no window
 ```
 
 ### `ConfigVisualizer` parameters
@@ -119,6 +151,7 @@ viz.preview(title="My setup")     # custom window title
 |---|---|---|---|
 | `title` | `str` | `"SPHinXsim - Configuration Preview"` | Window title |
 | `use_cpp` | `bool` | `True` | Run C++ geometry build. Raises `ImportError` if extension not installed. |
+| `screenshot_path` | `str \| Path \| None` | `None` | When set, saves a screenshot to this path instead of opening a window. Implies off-screen rendering. |
 
 After rendering, the CLI reports which tier was used:
 - `✅ Preview used C++ geometry (VTP meshes).`

--- a/sphinxsim/cli.py
+++ b/sphinxsim/cli.py
@@ -399,6 +399,11 @@ def cmd_preview(args: argparse.Namespace) -> int:
 
     use_cpp = not getattr(args, "no_cpp", False)
     off_screen = getattr(args, "off_screen", False)
+    screenshot_path = getattr(args, "screenshot", None)
+
+    # Screenshot mode implies off-screen rendering.
+    if screenshot_path:
+        off_screen = True
 
     print(f"🖼  Building configuration preview for: {resolved_config_path}")
     if use_cpp:
@@ -413,7 +418,7 @@ def cmd_preview(args: argparse.Namespace) -> int:
         off_screen=off_screen,
     )
     try:
-        visualizer.preview(use_cpp=use_cpp)
+        visualizer.preview(use_cpp=use_cpp, screenshot_path=screenshot_path)
         if use_cpp:
             if visualizer.used_cpp_geometry:
                 print("✅ Preview used C++ geometry (VTP meshes).")
@@ -421,6 +426,8 @@ def cmd_preview(args: argparse.Namespace) -> int:
                 print("ℹ️ Preview used C++ bounds fallback (no VTP meshes produced).")
         else:
             print("ℹ️ Preview rendered without C++ geometry (--no-cpp).")
+        if screenshot_path:
+            print(f"📸 Screenshot saved to: {screenshot_path}")
     except ImportError as exc:
         print(f"❌ {exc}", file=sys.stderr)
         return 1
@@ -512,7 +519,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
     print(
         "Commands: load FILE, generate DESCRIPTION FILE, "
         "update [--patch-mode] [--dry-run] [--strict true|false] INSTRUCTION, "
-        "validate, run, preview [--no-cpp], lock-geometry, unlock-geometry, lock-status, explore QUESTION, exit"
+        "validate, run, preview [--no-cpp] [--screenshot FILE], lock-geometry, unlock-geometry, lock-status, explore QUESTION, exit"
     )
     print("Note: relative paths are resolved from the current directory first, then .build-temp/.")
 
@@ -552,6 +559,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
             print("  validate                        - Reload and validate config from disk")
             print("  preview                         - Render geometry/BC preview (requires pyvista)")
             print("  preview --no-cpp                - Preview without C++ geometry build")
+            print("  preview --screenshot FILE        - Save a screenshot to FILE instead of interactive window")
             print("  run                             - Run simulation from loaded config")
             print("  lock-geometry                   - Manually lock geometry updates")
             print("  unlock-geometry                 - Unlock geometry updates")
@@ -698,11 +706,22 @@ def cmd_shell(args: argparse.Namespace) -> int:
                 print("No config loaded. Run 'load FILE' or 'generate' first.", file=sys.stderr)
                 continue
             no_cpp = "--no-cpp" in parts
+            # Extract --screenshot / -s value from shell input
+            screenshot_path = None
+            if "--screenshot" in parts:
+                idx = parts.index("--screenshot")
+                if idx + 1 < len(parts):
+                    screenshot_path = parts[idx + 1]
+            elif "-s" in parts:
+                idx = parts.index("-s")
+                if idx + 1 < len(parts):
+                    screenshot_path = parts[idx + 1]
             _ = cmd_preview(
                 argparse.Namespace(
                     config_file=str(config_path),
                     no_cpp=no_cpp,
                     off_screen=False,
+                    screenshot=screenshot_path,
                 )
             )
             continue
@@ -872,6 +891,12 @@ def _build_parser() -> argparse.ArgumentParser:
         "--off-screen",
         action="store_true",
         help="Render off-screen (no window). Useful for automated testing.",
+    )
+    prev.add_argument(
+        "--screenshot",
+        "-s",
+        default=None,
+        help="Save a screenshot to this file path instead of opening an interactive window.",
     )
     prev.set_defaults(func=cmd_preview)
 

--- a/sphinxsim/visualization/annotations.py
+++ b/sphinxsim/visualization/annotations.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sphinxsim.config.schemas import (
+        BodyConstraintConfig,
         FluidBoundaryConditionConfig,
         ObserverConfig,
         OrientedBoxConfig,
@@ -95,3 +96,30 @@ def observer_label(observer: "ObserverConfig") -> str:
         f"body={observer.observed_body}\n"
         f"var={variable_name}"
     )
+
+
+def body_constraint_label(constraint: "BodyConstraintConfig") -> str:
+    """Return an annotation label for a body constraint definition.
+
+    Covers both ``fixed`` and ``simbody`` constraint types.  When a
+    ``region`` (oriented box name) is specified the label notes it; otherwise
+    the constraint applies to the entire body.
+    """
+    parts = [f"Constraint → {constraint.body_name}", f"type={constraint.type.value}"]
+
+    if constraint.region is not None:
+        parts.append(f"region={constraint.region}")
+
+    if constraint.type.value == "simbody":
+        if constraint.mobilized_body is not None:
+            parts.append(f"mob={constraint.mobilized_body}")
+        if constraint.velocity is not None:
+            v = constraint.velocity
+            if len(v) == 2:
+                parts.append(f"v=({v[0]}, {v[1]})")
+            else:
+                parts.append(f"v=({v[0]}, {v[1]}, {v[2]})")
+        if constraint.angular_velocity is not None:
+            parts.append(f"ω={constraint.angular_velocity}")
+
+    return "\n".join(parts)

--- a/sphinxsim/visualization/annotations.py
+++ b/sphinxsim/visualization/annotations.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from sphinxsim.config.schemas import (
         FluidBoundaryConditionConfig,
+        ObserverConfig,
         OrientedBoxConfig,
         SimulationConfig,
     )
@@ -83,3 +84,14 @@ def gravity_label(config: "SimulationConfig") -> str | None:
     if len(g) == 2:
         return f"g = ({g[0]}, {g[1]})"
     return f"g = ({g[0]}, {g[1]}, {g[2]})"
+
+
+def observer_label(observer: "ObserverConfig") -> str:
+    """Return an annotation label for an observer definition."""
+    variable = observer.variable
+    variable_name = variable.real_type if variable.real_type is not None else variable.vector_type
+    return (
+        f"Observer: {observer.name}\n"
+        f"body={observer.observed_body}\n"
+        f"var={variable_name}"
+    )

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -233,6 +233,7 @@ class ConfigVisualizer:
         *,
         title: str = "SPHinXsim - Configuration Preview",
         use_cpp: bool = True,
+        screenshot_path: str | Path | None = None,
     ) -> None:
         """Render the configuration preview.
 
@@ -243,6 +244,10 @@ class ConfigVisualizer:
         use_cpp:
             When *True*, call ``buildGeometries()`` from the C++ extension.
             Raises :class:`ImportError` if the extension is not installed.
+        screenshot_path:
+            When provided, save a screenshot of the render to this file path
+            instead of opening an interactive window.  Forces off-screen
+            rendering so the screenshot can be produced headlessly.
         """
         try:
             import pyvista as pv  # type: ignore[import]
@@ -261,7 +266,9 @@ class ConfigVisualizer:
             self._shape_bounds_cache = None
         self._vtp_dir = vtp_dir
 
-        plotter = pv.Plotter(title=title, off_screen=self.off_screen)
+        # Screenshot mode implies off-screen rendering.
+        off_screen = self.off_screen or screenshot_path is not None
+        plotter = pv.Plotter(title=title, off_screen=off_screen)
         self._populate_plotter(plotter, vtp_dir)
         self._configure_default_view(plotter, ndim)
         plotter.add_axes()
@@ -282,7 +289,10 @@ class ConfigVisualizer:
             color="white",
         )
 
-        plotter.show()
+        if screenshot_path is not None:
+            plotter.screenshot(str(screenshot_path))
+        else:
+            plotter.show()
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -30,6 +30,7 @@ from sphinxsim.bindings.loader import load_sphinxsys_core, load_sphinxsys_core_n
 
 if TYPE_CHECKING:
     from sphinxsim.config.schemas import (
+        BodyConstraintConfig,
         OrientedBoxConfig,
         ShapeConfig,
         SimulationConfig,
@@ -48,6 +49,7 @@ _UNKNOWN_COLOUR = (0.60, 0.80, 0.40)     # green (shapes not in any body list)
 _INLET_OUTLET_COLOUR = (0.85, 0.20, 0.20)  # red
 _REGION_COLOUR = (0.85, 0.70, 0.10)        # yellow
 _OBSERVER_COLOUR = (0.93, 0.13, 0.93)      # magenta — observer positions
+_CONSTRAINT_COLOUR = (0.93, 0.55, 0.13)     # orange — body constraint regions
 
 
 def _body_colour(body_name: str, config: "SimulationConfig") -> tuple[float, float, float]:
@@ -446,6 +448,7 @@ class ConfigVisualizer:
         import pyvista as pv  # type: ignore[import]
 
         from sphinxsim.visualization.annotations import (
+            body_constraint_label,
             body_label,
             gravity_label,
             observer_label,
@@ -461,6 +464,11 @@ class ConfigVisualizer:
         body_names.update(b.name for b in config.continuum_bodies)
 
         rendered_shapes: set[str] = set()
+
+        # Build a name → shape lookup for later use (constraint labels, etc.)
+        shape_lookup: dict[str, "ShapeConfig"] = {
+            shape.name: shape for shape in config.geometries.shapes
+        }
 
         # --- Render each shape ---
         for shape in config.geometries.shapes:
@@ -522,6 +530,52 @@ class ConfigVisualizer:
                 always_visible=True,
             )
 
+        # --- Body constraints ---
+        # For constraints with a *region* (oriented box reference) we overlay
+        # the referenced box mesh with the constraint colour.  For constraints
+        # without a region the label is placed at the centroid of the
+        # constrained body's shape mesh (if available).
+        oriented_box_lookup = {
+            ob.name: ob for ob in config.geometries.oriented_boxes
+        }
+        for constraint in config.body_constraints:
+            label_text = body_constraint_label(constraint)
+
+            if constraint.region is not None and constraint.region in oriented_box_lookup:
+                ob = oriented_box_lookup[constraint.region]
+                mesh = self._load_oriented_box_mesh(ob, vtp_dir)
+                if mesh is not None:
+                    plotter.add_mesh(
+                        mesh,
+                        color=_CONSTRAINT_COLOUR,
+                        opacity=0.30,
+                        style="wireframe",
+                        line_width=3,
+                        label=f"Constraint: {constraint.body_name}",
+                    )
+                    plotter.add_point_labels(
+                        [mesh.center],
+                        [label_text],
+                        point_size=0,
+                        font_size=7,
+                        text_color="orange",
+                        always_visible=True,
+                    )
+            else:
+                # No region — try to label at the body shape centroid.
+                shape = shape_lookup.get(constraint.body_name)
+                if shape is not None:
+                    mesh = self._load_shape_mesh(shape, vtp_dir, config)
+                    if mesh is not None:
+                        plotter.add_point_labels(
+                            [mesh.center],
+                            [label_text],
+                            point_size=0,
+                            font_size=7,
+                            text_color="orange",
+                            always_visible=True,
+                        )
+
         # --- Domain bounding box ---
         if config.geometries.system_domain is not None:
             domain = config.geometries.system_domain
@@ -580,6 +634,7 @@ class ConfigVisualizer:
             ["Inlet/Outlet", _INLET_OUTLET_COLOUR],
             ["Region", _REGION_COLOUR],
             ["Observer", _OBSERVER_COLOUR],
+            ["Constraint", _CONSTRAINT_COLOUR],
         ]
         plotter.add_legend(
             [

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -50,6 +50,7 @@ _INLET_OUTLET_COLOUR = (0.85, 0.20, 0.20)  # red
 _REGION_COLOUR = (0.85, 0.70, 0.10)        # yellow
 _OBSERVER_COLOUR = (0.93, 0.13, 0.93)      # magenta — observer positions
 _CONSTRAINT_COLOUR = (0.93, 0.55, 0.13)     # orange — body constraint regions
+_GRAVITY_COLOUR = (0.10, 0.90, 0.90)        # cyan — gravity direction arrow
 
 
 def _body_colour(body_name: str, config: "SimulationConfig") -> tuple[float, float, float]:
@@ -599,9 +600,7 @@ class ConfigVisualizer:
             )
 
         # --- Gravity annotation ---
-        g_label = gravity_label(config)
-        if g_label:
-            plotter.add_text(g_label, position="lower_left", font_size=9, color="cyan")
+        self._add_gravity_arrow(plotter, config, pv)
 
         # --- Observer positions ---
         for observer in config.observers:
@@ -645,6 +644,7 @@ class ConfigVisualizer:
             ["Region", _REGION_COLOUR],
             ["Observer", _OBSERVER_COLOUR],
             ["Constraint", _CONSTRAINT_COLOUR],
+            ["Gravity", _GRAVITY_COLOUR],
         ]
         plotter.add_legend(
             [
@@ -655,6 +655,114 @@ class ConfigVisualizer:
             bcolor="black",
             border=True,
         )
+
+    def _add_gravity_arrow(self, plotter: Any, config: "SimulationConfig", pv: Any) -> None:
+        """Render gravity as a directional arrow with a text label.
+
+        The arrow originates near the upper-left of the domain bounding box and
+        points in the gravity direction.  Its length is scaled to a fraction of
+        the domain size so it remains visible regardless of scene scale.  When
+        gravity is unset, nothing is rendered.
+        """
+        from sphinxsim.visualization.annotations import gravity_label
+
+        g_label = gravity_label(config)
+        if g_label is None:
+            return
+
+        g = config.gravity
+        ndim = len(g)
+
+        # Determine a scene-appropriate arrow length from the domain bounds.
+        domain = config.geometries.system_domain
+        if domain is not None:
+            lower = list(domain.lower_bound)
+            upper = list(domain.upper_bound)
+        else:
+            # Fall back to the extent of all shape bounds if available.
+            lower, upper = self._scene_extent(ndim)
+
+        extent = [upper[i] - lower[i] for i in range(ndim)]
+        max_extent = max(extent) if extent else 1.0
+        if max_extent <= 0:
+            max_extent = 1.0
+        arrow_length = 0.25 * max_extent
+
+        # Gravity direction (unit vector).
+        magnitude = sum(c * c for c in g) ** 0.5
+        if magnitude == 0:
+            return
+        direction = tuple(c / magnitude for c in g)
+
+        # Arrow start point: near the upper-left corner of the domain so it
+        # doesn't overlap body shapes in the centre.
+        if ndim == 2:
+            start = (lower[0] + 0.05 * extent[0], upper[1] - 0.05 * extent[1], 0.0)
+            end = (
+                start[0] + direction[0] * arrow_length,
+                start[1] + direction[1] * arrow_length,
+                0.0,
+            )
+        else:
+            start = (lower[0] + 0.05 * extent[0], upper[1] - 0.05 * extent[1], upper[2] - 0.05 * extent[2])
+            end = tuple(start[i] + direction[i] * arrow_length for i in range(3))
+
+        try:
+            arrow = pv.Arrow(start=start, direction=direction, scale=arrow_length)
+            plotter.add_mesh(
+                arrow,
+                color=_GRAVITY_COLOUR,
+                line_width=4,
+                label="Gravity",
+            )
+        except Exception:
+            # If PyVista arrow construction fails, still show the text label.
+            pass
+
+        # Place the gravity text label just above the arrow start.
+        label_offset = 0.03 * max_extent
+        if ndim == 2:
+            label_pos = (start[0], start[1] + label_offset, 0.0)
+        else:
+            label_pos = (start[0], start[1] + label_offset, start[2])
+
+        try:
+            plotter.add_point_labels(
+                [label_pos],
+                [g_label],
+                point_size=0,
+                font_size=9,
+                text_color="cyan",
+                always_visible=True,
+            )
+        except Exception:
+            # Fall back to corner text if point labels are unavailable.
+            plotter.add_text(g_label, position="lower_left", font_size=9, color="cyan")
+
+    def _scene_extent(self, ndim: int) -> tuple[list[float], list[float]]:
+        """Return coarse lower/upper bounds for the scene.
+
+        Used when ``system_domain`` is absent so the gravity arrow can still be
+        scaled to the scene.  Falls back to a unit box if no bounds are
+        available.
+        """
+        lower = [0.0] * ndim
+        upper = [1.0] * ndim
+
+        if self._shape_bounds_cache is not None:
+            for bounds in self._shape_bounds_cache.values():
+                lo, hi = list(bounds[0]), list(bounds[1])
+                for i in range(min(ndim, len(lo))):
+                    lower[i] = min(lower[i], lo[i])
+                    upper[i] = max(upper[i], hi[i])
+
+        # Pad slightly so the arrow sits just inside the scene.
+        for i in range(ndim):
+            pad = 0.05 * max(upper[i] - lower[i], 1.0)
+            lower[i] -= pad
+            upper[i] += pad
+
+        return lower, upper
 
     def _load_shape_mesh(
         self,

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -47,6 +47,7 @@ _CONTINUUM_COLOUR = (0.90, 0.60, 0.10)   # amber
 _UNKNOWN_COLOUR = (0.60, 0.80, 0.40)     # green (shapes not in any body list)
 _INLET_OUTLET_COLOUR = (0.85, 0.20, 0.20)  # red
 _REGION_COLOUR = (0.85, 0.70, 0.10)        # yellow
+_OBSERVER_COLOUR = (0.93, 0.13, 0.93)      # magenta — observer positions
 
 
 def _body_colour(body_name: str, config: "SimulationConfig") -> tuple[float, float, float]:
@@ -447,6 +448,7 @@ class ConfigVisualizer:
         from sphinxsim.visualization.annotations import (
             body_label,
             gravity_label,
+            observer_label,
             oriented_box_label,
         )
 
@@ -537,6 +539,38 @@ class ConfigVisualizer:
         if g_label:
             plotter.add_text(g_label, position="lower_left", font_size=9, color="cyan")
 
+        # --- Observer positions ---
+        for observer in config.observers:
+            if not observer.positions:
+                continue
+
+            points: list[tuple[float, float, float]] = []
+            for position in observer.positions:
+                if len(position) == 2:
+                    points.append((float(position[0]), float(position[1]), 0.0))
+                elif len(position) == 3:
+                    points.append((float(position[0]), float(position[1]), float(position[2])))
+
+            if not points:
+                continue
+
+            observer_points = pv.PolyData(points)
+            plotter.add_mesh(
+                observer_points,
+                color=_OBSERVER_COLOUR,
+                point_size=10,
+                render_points_as_spheres=True,
+                label=f"Observer: {observer.name}",
+            )
+            plotter.add_point_labels(
+                [points[0]],
+                [observer_label(observer)],
+                point_size=0,
+                font_size=7,
+                text_color="magenta",
+                always_visible=True,
+            )
+
         # --- Legend ---
         legend_entries = [
             ["Fluid body", _FLUID_COLOUR],
@@ -545,6 +579,7 @@ class ConfigVisualizer:
             ["Other shape", _UNKNOWN_COLOUR],
             ["Inlet/Outlet", _INLET_OUTLET_COLOUR],
             ["Region", _REGION_COLOUR],
+            ["Observer", _OBSERVER_COLOUR],
         ]
         plotter.add_legend(
             [

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -688,36 +688,29 @@ class ConfigVisualizer:
             max_extent = 1.0
         arrow_length = 0.25 * max_extent
 
-        # Gravity direction (unit vector).
+        # Gravity direction (unit vector).  PyVista's Arrow always requires a
+        # 3-D direction vector, so pad 2-D gravity with a zero z-component.
         magnitude = sum(c * c for c in g) ** 0.5
         if magnitude == 0:
             return
         direction = tuple(c / magnitude for c in g)
+        if ndim == 2:
+            direction = direction + (0.0,)
 
         # Arrow start point: near the upper-left corner of the domain so it
         # doesn't overlap body shapes in the centre.
         if ndim == 2:
             start = (lower[0] + 0.05 * extent[0], upper[1] - 0.05 * extent[1], 0.0)
-            end = (
-                start[0] + direction[0] * arrow_length,
-                start[1] + direction[1] * arrow_length,
-                0.0,
-            )
         else:
             start = (lower[0] + 0.05 * extent[0], upper[1] - 0.05 * extent[1], upper[2] - 0.05 * extent[2])
-            end = tuple(start[i] + direction[i] * arrow_length for i in range(3))
 
-        try:
-            arrow = pv.Arrow(start=start, direction=direction, scale=arrow_length)
-            plotter.add_mesh(
-                arrow,
-                color=_GRAVITY_COLOUR,
-                line_width=4,
-                label="Gravity",
-            )
-        except Exception:
-            # If PyVista arrow construction fails, still show the text label.
-            pass
+        arrow = pv.Arrow(start=start, direction=direction, scale=arrow_length)
+        plotter.add_mesh(
+            arrow,
+            color=_GRAVITY_COLOUR,
+            line_width=4,
+            label="Gravity",
+        )
 
         # Place the gravity text label just above the arrow start.
         label_offset = 0.03 * max_extent

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -481,6 +481,27 @@ class ConfigVisualizer:
             shape.name: shape for shape in config.geometries.shapes
         }
 
+        occupied_points: list[tuple[float, float, float]] = []
+        scene_bounds: list[float] | None = None
+
+        def _update_scene_bounds(mesh: Any) -> None:
+            nonlocal scene_bounds
+            try:
+                bx = [float(v) for v in mesh.bounds]
+            except Exception:
+                return
+            if len(bx) != 6:
+                return
+            if scene_bounds is None:
+                scene_bounds = bx[:]
+                return
+            scene_bounds[0] = min(scene_bounds[0], bx[0])
+            scene_bounds[1] = max(scene_bounds[1], bx[1])
+            scene_bounds[2] = min(scene_bounds[2], bx[2])
+            scene_bounds[3] = max(scene_bounds[3], bx[3])
+            scene_bounds[4] = min(scene_bounds[4], bx[4])
+            scene_bounds[5] = max(scene_bounds[5], bx[5])
+
         # --- Render each shape ---
         for shape in config.geometries.shapes:
             if shape.type.value == "complex_shape":
@@ -503,6 +524,7 @@ class ConfigVisualizer:
                 style=style,
                 label=shape.name,
             )
+            _update_scene_bounds(mesh)
 
             label_anchor = _label_anchor_point(mesh)
             label_text = body_label(shape.name, config) if is_body else shape.name
@@ -513,6 +535,13 @@ class ConfigVisualizer:
                 font_size=8,
                 text_color="white",
                 always_visible=True,
+            )
+            occupied_points.append(
+                (
+                    float(mesh.center[0]),
+                    float(mesh.center[1]),
+                    float(mesh.center[2]) if len(mesh.center) > 2 else 0.0,
+                )
             )
             rendered_shapes.add(shape.name)
 
@@ -531,6 +560,7 @@ class ConfigVisualizer:
                 line_width=2,
                 label=ob.name,
             )
+            _update_scene_bounds(mesh)
             label_text = oriented_box_label(ob, config)
             plotter.add_point_labels(
                 [mesh.center],
@@ -539,6 +569,13 @@ class ConfigVisualizer:
                 font_size=7,
                 text_color="yellow",
                 always_visible=True,
+            )
+            occupied_points.append(
+                (
+                    float(mesh.center[0]),
+                    float(mesh.center[1]),
+                    float(mesh.center[2]) if len(mesh.center) > 2 else 0.0,
+                )
             )
 
         # --- Body constraints ---
@@ -598,9 +635,16 @@ class ConfigVisualizer:
                 style="wireframe",
                 line_width=1,
             )
+            _update_scene_bounds(domain_mesh)
 
         # --- Gravity annotation ---
-        self._add_gravity_arrow(plotter, config, pv)
+        self._add_gravity_arrow(
+            plotter,
+            config,
+            pv,
+            occupied_points,
+            scene_bounds=tuple(scene_bounds) if scene_bounds is not None else None,
+        )
 
         # --- Observer positions ---
         for observer in config.observers:
@@ -656,13 +700,21 @@ class ConfigVisualizer:
             border=True,
         )
 
-    def _add_gravity_arrow(self, plotter: Any, config: "SimulationConfig", pv: Any) -> None:
+    def _add_gravity_arrow(
+        self,
+        plotter: Any,
+        config: "SimulationConfig",
+        pv: Any,
+        occupied_points: list[tuple[float, float, float]] | None = None,
+        scene_bounds: tuple[float, ...] | None = None,
+    ) -> None:
         """Render gravity as a directional arrow with a text label.
 
-        The arrow originates near the upper-left of the domain bounding box and
-        points in the gravity direction.  Its length is scaled to a fraction of
-        the domain size so it remains visible regardless of scene scale.  When
-        gravity is unset, nothing is rendered.
+        In 2-D, the arrow is anchored near the lower-left of the scene so it is
+        easier to spot and appears close to the on-screen axes widget. In 3-D,
+        it originates near the upper-left/front of the domain bounding box. Its
+        length is scaled to a fraction of the domain size so it remains visible
+        regardless of scene scale. When gravity is unset, nothing is rendered.
         """
         from sphinxsim.visualization.annotations import gravity_label
 
@@ -678,6 +730,12 @@ class ConfigVisualizer:
         if domain is not None:
             lower = list(domain.lower_bound)
             upper = list(domain.upper_bound)
+        elif scene_bounds is not None and len(scene_bounds) == 6:
+            lower = [float(scene_bounds[0]), float(scene_bounds[2])]
+            upper = [float(scene_bounds[1]), float(scene_bounds[3])]
+            if ndim == 3:
+                lower.append(float(scene_bounds[4]))
+                upper.append(float(scene_bounds[5]))
         else:
             # Fall back to the extent of all shape bounds if available.
             lower, upper = self._scene_extent(ndim)
@@ -697,10 +755,41 @@ class ConfigVisualizer:
         if ndim == 2:
             direction = direction + (0.0,)
 
-        # Arrow start point: near the upper-left corner of the domain so it
-        # doesn't overlap body shapes in the centre.
+        # Arrow start point:
+        # - 2-D: choose from corner candidates and prefer visually empty space.
+        # - 3-D: keep upper-left/front to avoid clutter in perspective view.
         if ndim == 2:
-            start = (lower[0] + 0.05 * extent[0], upper[1] - 0.05 * extent[1], 0.0)
+            candidates = [
+                (lower[0] + 0.10 * extent[0], lower[1] + 0.18 * extent[1], 0.0),
+                (lower[0] + 0.10 * extent[0], upper[1] - 0.18 * extent[1], 0.0),
+                (upper[0] - 0.10 * extent[0], lower[1] + 0.18 * extent[1], 0.0),
+                (upper[0] - 0.10 * extent[0], upper[1] - 0.18 * extent[1], 0.0),
+            ]
+
+            points = occupied_points or []
+
+            def _score(candidate: tuple[float, float, float]) -> float:
+                # Prefer larger distance from rendered geometry centers.
+                if points:
+                    nearest = min(
+                        (candidate[0] - p[0]) ** 2 + (candidate[1] - p[1]) ** 2
+                        for p in points
+                    )
+                else:
+                    nearest = 0.0
+
+                # Prefer starts whose arrow end remains within scene bounds.
+                end_x = candidate[0] + direction[0] * arrow_length
+                end_y = candidate[1] + direction[1] * arrow_length
+                margin_x = 0.03 * extent[0]
+                margin_y = 0.03 * extent[1]
+                inside = (
+                    lower[0] + margin_x <= end_x <= upper[0] - margin_x
+                    and lower[1] + margin_y <= end_y <= upper[1] - margin_y
+                )
+                return nearest + (1e6 if inside else 0.0)
+
+            start = max(candidates, key=_score)
         else:
             start = (lower[0] + 0.05 * extent[0], upper[1] - 0.05 * extent[1], upper[2] - 0.05 * extent[2])
 
@@ -736,7 +825,7 @@ class ConfigVisualizer:
         """Return coarse lower/upper bounds for the scene.
 
         Used when ``system_domain`` is absent so the gravity arrow can still be
-        scaled to the scene.  Falls back to a unit box if no bounds are
+        scaled to the scene.  Falls back to a unit box if no bounds arepreview
         available.
         """
         lower = [0.0] * ndim

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -413,6 +413,201 @@ class TestPreviewObservers:
 
 
 # ---------------------------------------------------------------------------
+# Body constraint label tests
+# ---------------------------------------------------------------------------
+
+class TestConstraintLabel:
+    def test_fixed_constraint_label(self, fluid_config):
+        from sphinxsim.visualization.annotations import body_constraint_label
+
+        data = copy.deepcopy(fluid_config.model_dump(exclude_none=True))
+        data["body_constraints"] = [
+            {"body_name": "WallBoundary", "type": "fixed"}
+        ]
+        cfg = SimulationConfig(**data)
+
+        label = body_constraint_label(cfg.body_constraints[0])
+        assert "Constraint → WallBoundary" in label
+        assert "type=fixed" in label
+
+    def test_fixed_constraint_with_region_label(self, fluid_config):
+        from sphinxsim.visualization.annotations import body_constraint_label
+
+        data = copy.deepcopy(fluid_config.model_dump(exclude_none=True))
+        data["geometries"]["oriented_boxes"].append(
+            {
+                "name": "ClampRegion",
+                "type": "region",
+                "half_size": [0.1, 0.1],
+                "transform": {
+                    "translation": [0.5, 0.5],
+                    "rotation_angle": 0.0,
+                    "rotation_axis": [0.0, 0.0, 1.0],
+                },
+            }
+        )
+        data["body_constraints"] = [
+            {"body_name": "WallBoundary", "type": "fixed", "region": "ClampRegion"}
+        ]
+        cfg = SimulationConfig(**data)
+
+        label = body_constraint_label(cfg.body_constraints[0])
+        assert "Constraint → WallBoundary" in label
+        assert "type=fixed" in label
+        assert "region=ClampRegion" in label
+
+    def test_simbody_constraint_label(self, fluid_config):
+        from sphinxsim.visualization.annotations import body_constraint_label
+
+        data = copy.deepcopy(fluid_config.model_dump(exclude_none=True))
+        # Simbody constraints require solver_parameters.restart
+        data["solver_parameters"]["restart"] = {
+            "restore_step": 0,
+            "save_interval": 1000,
+            "summary_enabled": False,
+        }
+        data["body_constraints"] = [
+            {
+                "body_name": "WallBoundary",
+                "type": "simbody",
+                "mobilized_body": "planar",
+                "velocity": [0.0, -0.03],
+                "angular_velocity": 2.0,
+            }
+        ]
+        cfg = SimulationConfig(**data)
+
+        label = body_constraint_label(cfg.body_constraints[0])
+        assert "Constraint → WallBoundary" in label
+        assert "type=simbody" in label
+        assert "mob=planar" in label
+        assert "v=(0.0, -0.03)" in label
+        assert "ω=2.0" in label
+
+
+# ---------------------------------------------------------------------------
+# Body constraint preview tests
+# ---------------------------------------------------------------------------
+
+class TestPreviewConstraints:
+    def test_preview_renders_constraint_with_region(self, fluid_config, tmp_path, monkeypatch):
+        """A constraint with a region should not raise an error during visualization."""
+        from sphinxsim.visualization.preview import ConfigVisualizer
+
+        data = copy.deepcopy(fluid_config.model_dump(exclude_none=True))
+        data["geometries"].pop("system_domain", None)
+        data["geometries"]["oriented_boxes"].append(
+            {
+                "name": "ClampRegion",
+                "type": "region",
+                "half_size": [0.1, 0.1],
+                "transform": {
+                    "translation": [0.5, 0.5],
+                    "rotation_angle": 0.0,
+                    "rotation_axis": [0.0, 0.0, 1.0],
+                },
+            }
+        )
+        data["body_constraints"] = [
+            {"body_name": "WallBoundary", "type": "fixed", "region": "ClampRegion"}
+        ]
+        cfg = SimulationConfig(**data)
+        viz = ConfigVisualizer(cfg, tmp_path, off_screen=True)
+
+        # Mock PyVista to avoid requiring a display or actual rendering
+        class MockPolyData:
+            def __init__(self, points):
+                self.points = points
+                self.center = [0.5, 0.5, 0.0] if len(points) > 0 else [0.0, 0.0, 0.0]
+                self.bounds = [[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]
+
+        class MockPlotter:
+            def add_mesh(self, mesh, **kwargs):
+                pass
+
+            def add_point_labels(self, points, labels, **kwargs):
+                pass
+
+            def add_text(self, *args, **kwargs):
+                pass
+
+            def add_legend(self, *args, **kwargs):
+                pass
+
+        class MockPyVista:
+            def Plotter(self, **kwargs):
+                return MockPlotter()
+
+            @staticmethod
+            def PolyData(points):
+                return MockPolyData(points)
+
+        # Mock pyvista import
+        import sys
+
+        monkeypatch.setitem(sys.modules, "pyvista", MockPyVista())
+
+        # Should not raise an error
+        try:
+            plotter = MockPlotter()
+            viz._populate_plotter(plotter, vtp_dir=None)
+        except Exception as e:
+            pytest.fail(f"_populate_plotter raised {type(e).__name__}: {e}")
+
+    def test_preview_renders_constraint_without_region(self, fluid_config, tmp_path, monkeypatch):
+        """A constraint without a region should not raise an error during visualization."""
+        from sphinxsim.visualization.preview import ConfigVisualizer
+
+        data = copy.deepcopy(fluid_config.model_dump(exclude_none=True))
+        data["geometries"].pop("system_domain", None)
+        data["body_constraints"] = [
+            {"body_name": "WallBoundary", "type": "fixed"}
+        ]
+        cfg = SimulationConfig(**data)
+        viz = ConfigVisualizer(cfg, tmp_path, off_screen=True)
+
+        # Mock PyVista to avoid requiring a display or actual rendering
+        class MockPolyData:
+            def __init__(self, points):
+                self.points = points
+                self.center = [0.5, 0.5, 0.0] if len(points) > 0 else [0.0, 0.0, 0.0]
+                self.bounds = [[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]
+
+        class MockPlotter:
+            def add_mesh(self, mesh, **kwargs):
+                pass
+
+            def add_point_labels(self, points, labels, **kwargs):
+                pass
+
+            def add_text(self, *args, **kwargs):
+                pass
+
+            def add_legend(self, *args, **kwargs):
+                pass
+
+        class MockPyVista:
+            def Plotter(self, **kwargs):
+                return MockPlotter()
+
+            @staticmethod
+            def PolyData(points):
+                return MockPolyData(points)
+
+        # Mock pyvista import
+        import sys
+
+        monkeypatch.setitem(sys.modules, "pyvista", MockPyVista())
+
+        # Should not raise an error
+        try:
+            plotter = MockPlotter()
+            viz._populate_plotter(plotter, vtp_dir=None)
+        except Exception as e:
+            pytest.fail(f"_populate_plotter raised {type(e).__name__}: {e}")
+
+
+# ---------------------------------------------------------------------------
 # CLI preview command tests (no PyVista / no C++ required)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -393,6 +393,15 @@ class TestPreviewObservers:
             def PolyData(points):
                 return {"points": points}
 
+            @staticmethod
+            def Arrow(start, direction, scale):
+                return {
+                    "type": "arrow",
+                    "start": start,
+                    "direction": direction,
+                    "scale": scale,
+                }
+
         fake_plotter = FakePlotter()
         with patch.dict(sys.modules, {"pyvista": FakePyVista}):
             viz._populate_plotter(fake_plotter, vtp_dir=None)
@@ -542,6 +551,15 @@ class TestPreviewConstraints:
             def PolyData(points):
                 return MockPolyData(points)
 
+            @staticmethod
+            def Arrow(start, direction, scale):
+                return {
+                    "type": "arrow",
+                    "start": start,
+                    "direction": direction,
+                    "scale": scale,
+                }
+
         # Mock pyvista import
         import sys
 
@@ -593,6 +611,15 @@ class TestPreviewConstraints:
             @staticmethod
             def PolyData(points):
                 return MockPolyData(points)
+
+            @staticmethod
+            def Arrow(start, direction, scale):
+                return {
+                    "type": "arrow",
+                    "start": start,
+                    "direction": direction,
+                    "scale": scale,
+                }
 
         # Mock pyvista import
         import sys
@@ -815,6 +842,15 @@ class TestScreenshot:
                 return MockPolyData(points)
 
             @staticmethod
+            def Arrow(start, direction, scale):
+                return {
+                    "type": "arrow",
+                    "start": start,
+                    "direction": direction,
+                    "scale": scale,
+                }
+
+            @staticmethod
             def Box(bounds):
                 class MockBox:
                     def __init__(self):
@@ -879,6 +915,15 @@ class TestScreenshot:
                         self.bounds = [[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]
 
                 return MockPolyData(points)
+
+            @staticmethod
+            def Arrow(start, direction, scale):
+                return {
+                    "type": "arrow",
+                    "start": start,
+                    "direction": direction,
+                    "scale": scale,
+                }
 
             @staticmethod
             def Box(bounds):
@@ -1059,6 +1104,9 @@ class _FakePyVista:
 
     @staticmethod
     def Arrow(start, direction, scale):
+        # Match PyVista's requirement: both vectors must be 3-D.
+        if len(start) != 3 or len(direction) != 3:
+            raise ValueError("Arrow start and direction must be 3-D vectors")
         return {"type": "arrow", "start": start, "direction": direction, "scale": scale}
 
     @staticmethod
@@ -1090,7 +1138,7 @@ class TestPreviewGravityArrow:
 
         # The arrow direction should match the gravity direction (normalised).
         arrow = arrow_calls[0]["mesh"]
-        assert arrow["direction"] == (0.0, -1.0)
+        assert arrow["direction"] == (0.0, -1.0, 0.0)
 
         # The gravity text label should have been rendered.
         assert len(fake_plotter.label_calls) > 0 or len(fake_plotter.text_calls) > 0

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1013,3 +1013,137 @@ class TestShellScreenshot:
 
         assert rc == 0
         fake_visualizer.preview.assert_called_once_with(use_cpp=True, screenshot_path="short.png")
+
+
+# ---------------------------------------------------------------------------
+# Gravity arrow preview tests
+# ---------------------------------------------------------------------------
+
+class _FakeMesh:
+    """Lightweight stand-in for a PyVista mesh with bounds/center."""
+
+    def __init__(self, bounds: tuple[float, ...]):
+        # bounds is a flat tuple (x0, x1, y0, y1, z0, z1)
+        self.bounds = bounds
+        x0, x1, y0, y1, z0, z1 = bounds
+        self.center = ((x0 + x1) / 2, (y0 + y1) / 2, (z0 + z1) / 2)
+
+
+class _FakePlotter:
+    """Records all add_* calls for later assertions."""
+
+    def __init__(self):
+        self.mesh_calls: list[dict[str, Any]] = []
+        self.label_calls: list[dict[str, Any]] = []
+        self.text_calls: list[dict[str, Any]] = []
+
+    def add_mesh(self, mesh, **kwargs):
+        self.mesh_calls.append({"mesh": mesh, **kwargs})
+
+    def add_point_labels(self, points, labels, **kwargs):
+        self.label_calls.append({"points": points, "labels": labels, **kwargs})
+
+    def add_text(self, *args, **kwargs):
+        self.text_calls.append({"args": args, **kwargs})
+
+    def add_legend(self, *args, **kwargs):
+        return None
+
+
+class _FakePyVista:
+    """Mock pyvista module providing Box, Arrow, PolyData, read."""
+
+    @staticmethod
+    def Box(bounds):
+        return _FakeMesh(bounds=bounds)
+
+    @staticmethod
+    def Arrow(start, direction, scale):
+        return {"type": "arrow", "start": start, "direction": direction, "scale": scale}
+
+    @staticmethod
+    def PolyData(points):
+        return _FakeMesh(bounds=(0.0, 1.0, 0.0, 1.0, 0.0, 0.0))
+
+    @staticmethod
+    def read(path):
+        return _FakeMesh(bounds=(0.0, 1.0, 0.0, 1.0, 0.0, 0.0))
+
+
+class TestPreviewGravityArrow:
+    """Tests that the gravity arrow is rendered in the preview plotter."""
+
+    def test_gravity_arrow_added_when_gravity_set(self, fluid_config, tmp_path):
+        """When gravity is set, _populate_plotter should add an arrow mesh."""
+        from sphinxsim.visualization.preview import ConfigVisualizer
+
+        viz = ConfigVisualizer(fluid_config, tmp_path, off_screen=True)
+
+        fake_plotter = _FakePlotter()
+        with patch.dict(sys.modules, {"pyvista": _FakePyVista}):
+            viz._populate_plotter(fake_plotter, vtp_dir=None)
+
+        # An arrow mesh should have been added with the gravity colour and label.
+        arrow_calls = [c for c in fake_plotter.mesh_calls if c.get("label") == "Gravity"]
+        assert len(arrow_calls) == 1
+        assert arrow_calls[0]["color"] == (0.10, 0.90, 0.90)
+
+        # The arrow direction should match the gravity direction (normalised).
+        arrow = arrow_calls[0]["mesh"]
+        assert arrow["direction"] == (0.0, -1.0)
+
+        # The gravity text label should have been rendered.
+        assert len(fake_plotter.label_calls) > 0 or len(fake_plotter.text_calls) > 0
+
+    def test_no_gravity_arrow_when_gravity_unset(self, fluid_config, tmp_path):
+        """When gravity is None, no arrow mesh should be added."""
+        from sphinxsim.visualization.preview import ConfigVisualizer
+
+        data = copy.deepcopy(fluid_config.model_dump(exclude_none=True))
+        data["gravity"] = None
+        cfg = SimulationConfig(**data)
+        viz = ConfigVisualizer(cfg, tmp_path, off_screen=True)
+
+        fake_plotter = _FakePlotter()
+        with patch.dict(sys.modules, {"pyvista": _FakePyVista}):
+            viz._populate_plotter(fake_plotter, vtp_dir=None)
+
+        # No arrow mesh should have been added.
+        arrow_calls = [c for c in fake_plotter.mesh_calls if c.get("label") == "Gravity"]
+        assert len(arrow_calls) == 0
+
+    def test_gravity_arrow_3d(self, tmp_path):
+        """A 3-D gravity vector should produce an arrow with 3-D direction."""
+        from sphinxsim.visualization.preview import ConfigVisualizer
+
+        data = _minimal_fluid_config()
+        data["geometries"]["system_domain"] = {
+            "lower_bound": [0.0, 0.0, 0.0],
+            "upper_bound": [1.0, 1.0, 1.0],
+        }
+        data["geometries"]["shapes"] = [
+            {
+                "name": "WaterBody",
+                "type": "bounding_box",
+                "lower_bound": [0.0, 0.0, 0.0],
+                "upper_bound": [0.4, 0.2, 0.4],
+            },
+            {
+                "name": "WallBoundary",
+                "type": "bounding_box",
+                "lower_bound": [-0.05, -0.05, -0.05],
+                "upper_bound": [1.05, 1.05, 1.05],
+            },
+        ]
+        data["gravity"] = [0.0, 0.0, -9.81]
+        cfg = SimulationConfig(**data)
+        viz = ConfigVisualizer(cfg, tmp_path, off_screen=True)
+
+        fake_plotter = _FakePlotter()
+        with patch.dict(sys.modules, {"pyvista": _FakePyVista}):
+            viz._populate_plotter(fake_plotter, vtp_dir=None)
+
+        arrow_calls = [c for c in fake_plotter.mesh_calls if c.get("label") == "Gravity"]
+        assert len(arrow_calls) == 1
+        arrow = arrow_calls[0]["mesh"]
+        assert arrow["direction"] == (0.0, 0.0, -1.0)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -242,6 +242,27 @@ class TestGravityLabel:
         assert label is None
 
 
+class TestObserverLabel:
+    def test_observer_label_includes_name_body_and_variable(self, fluid_config):
+        from sphinxsim.visualization.annotations import observer_label
+
+        data = copy.deepcopy(fluid_config.model_dump(exclude_none=True))
+        data["observers"] = [
+            {
+                "name": "ProbeA",
+                "observed_body": "WaterBody",
+                "variable": {"real_type": "Pressure"},
+                "positions": [[0.1, 0.1]],
+            }
+        ]
+        cfg = SimulationConfig(**data)
+
+        label = observer_label(cfg.observers[0])
+        assert "Observer: ProbeA" in label
+        assert "body=WaterBody" in label
+        assert "var=Pressure" in label
+
+
 # ---------------------------------------------------------------------------
 # ConfigVisualizer.preview — no-pyvista guard test
 # ---------------------------------------------------------------------------
@@ -329,6 +350,66 @@ class TestPreviewViewMode:
         viz._add_view_direction_widgets(fake_plotter, ndim=2)
 
         assert fake_plotter.titles == ["+z", "-z"]
+
+
+class TestPreviewObservers:
+    def test_populate_plotter_renders_observer_points(self, fluid_config, tmp_path):
+        from sphinxsim.visualization.preview import ConfigVisualizer
+
+        data = copy.deepcopy(fluid_config.model_dump(exclude_none=True))
+        data["geometries"].pop("system_domain", None)
+        data["observers"] = [
+            {
+                "name": "ProbeA",
+                "observed_body": "WaterBody",
+                "variable": {"real_type": "Pressure"},
+                "positions": [[0.1, 0.1], [0.2, 0.1]],
+            }
+        ]
+        cfg = SimulationConfig(**data)
+        viz = ConfigVisualizer(cfg, tmp_path, off_screen=True)
+
+        class FakePlotter:
+            def __init__(self):
+                self.mesh_calls: list[dict[str, Any]] = []
+                self.point_label_calls: list[dict[str, Any]] = []
+
+            def add_mesh(self, mesh, **kwargs):
+                self.mesh_calls.append({"mesh": mesh, **kwargs})
+
+            def add_point_labels(self, points, labels, **kwargs):
+                self.point_label_calls.append(
+                    {"points": points, "labels": labels, **kwargs}
+                )
+
+            def add_text(self, *args, **kwargs):
+                return None
+
+            def add_legend(self, *args, **kwargs):
+                return None
+
+        class FakePyVista:
+            @staticmethod
+            def PolyData(points):
+                return {"points": points}
+
+        fake_plotter = FakePlotter()
+        with patch.dict(sys.modules, {"pyvista": FakePyVista}):
+            viz._populate_plotter(fake_plotter, vtp_dir=None)
+
+        observer_mesh_calls = [
+            call for call in fake_plotter.mesh_calls if call.get("label") == "Observer: ProbeA"
+        ]
+        assert len(observer_mesh_calls) == 1
+        assert observer_mesh_calls[0]["color"] == (0.93, 0.13, 0.93)
+        assert observer_mesh_calls[0]["point_size"] == 10
+
+        observer_label_calls = [
+            call
+            for call in fake_plotter.point_label_calls
+            if call["labels"] and "Observer: ProbeA" in call["labels"][0]
+        ]
+        assert len(observer_label_calls) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -644,7 +644,7 @@ class TestCLIPreviewCommand:
 
         assert rc == 0
         MockViz.assert_called_once()
-        fake_visualizer.preview.assert_called_once_with(use_cpp=True)
+        fake_visualizer.preview.assert_called_once_with(use_cpp=True, screenshot_path=None)
 
     def test_preview_no_cpp_flag(self, build_temp_path):
         cfg = self._write_config(build_temp_path)
@@ -659,7 +659,7 @@ class TestCLIPreviewCommand:
                 rc = main(["preview", str(cfg), "--no-cpp"])
 
         assert rc == 0
-        fake_visualizer.preview.assert_called_once_with(use_cpp=False)
+        fake_visualizer.preview.assert_called_once_with(use_cpp=False, screenshot_path=None)
 
     def test_preview_invalid_config_returns_nonzero(self, build_temp_path, capsys):
         bad = _minimal_fluid_config()
@@ -732,7 +732,7 @@ class TestShellPreview:
 
         assert rc == 0
         MockViz.assert_called_once()
-        fake_visualizer.preview.assert_called_once_with(use_cpp=True)
+        fake_visualizer.preview.assert_called_once_with(use_cpp=True, screenshot_path=None)
 
     def test_shell_preview_no_cpp_flag(self, build_temp_path):
         _, rel = self._write_config(build_temp_path)
@@ -748,7 +748,7 @@ class TestShellPreview:
                     rc = main(["shell"])
 
         assert rc == 0
-        fake_visualizer.preview.assert_called_once_with(use_cpp=False)
+        fake_visualizer.preview.assert_called_once_with(use_cpp=False, screenshot_path=None)
 
     def test_shell_help_mentions_preview(self, build_temp_path, capsys):
         inputs = ["help", "exit"]
@@ -756,3 +756,260 @@ class TestShellPreview:
             rc = main(["shell"])
         assert rc == 0
         assert "preview" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Screenshot tests
+# ---------------------------------------------------------------------------
+
+class TestScreenshot:
+    """Tests for the screenshot output feature."""
+
+    def test_preview_screenshot_calls_plotter_screenshot(self, tmp_path, monkeypatch):
+        """preview() with screenshot_path should call plotter.screenshot() instead of plotter.show()."""
+        import sphinxsim.visualization.preview as pv_mod
+
+        cfg = SimulationConfig(**_minimal_fluid_config())
+
+        screenshot_calls: list[str] = []
+        show_calls: list[int] = []
+
+        class ScreenshotMockPlotter:
+            window_size = (800, 600)
+
+            def add_mesh(self, mesh, **kwargs):
+                pass
+
+            def add_point_labels(self, points, labels, **kwargs):
+                pass
+
+            def add_text(self, *args, **kwargs):
+                pass
+
+            def add_legend(self, *args, **kwargs):
+                pass
+
+            def screenshot(self, path):
+                screenshot_calls.append(path)
+
+            def show(self):
+                show_calls.append(1)
+
+            def __getattr__(self, name):
+                def _noop(*args, **kwargs):
+                    pass
+                return _noop
+
+        class ScreenshotMockPyVista:
+            def Plotter(self, **kwargs):
+                return ScreenshotMockPlotter()
+
+            @staticmethod
+            def PolyData(points):
+                class MockPolyData:
+                    def __init__(self, pts):
+                        self.points = pts
+                        self.center = [0.5, 0.5, 0.0] if len(pts) > 0 else [0.0, 0.0, 0.0]
+                        self.bounds = [[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]
+
+                return MockPolyData(points)
+
+            @staticmethod
+            def Box(bounds):
+                class MockBox:
+                    def __init__(self):
+                        self.bounds = bounds
+                return MockBox()
+
+        monkeypatch.setitem(sys.modules, "pyvista", ScreenshotMockPyVista())
+
+        viz = pv_mod.ConfigVisualizer(cfg, tmp_path, off_screen=False)
+        out_file = str(tmp_path / "screenshot.png")
+        viz.preview(use_cpp=False, screenshot_path=out_file)
+
+        assert len(screenshot_calls) == 1
+        assert screenshot_calls[0] == out_file
+        assert len(show_calls) == 0  # show() should NOT be called when screenshot_path is set
+
+    def test_preview_without_screenshot_calls_show(self, tmp_path, monkeypatch):
+        """preview() without screenshot_path should call plotter.show() and NOT plotter.screenshot()."""
+        import sphinxsim.visualization.preview as pv_mod
+
+        cfg = SimulationConfig(**_minimal_fluid_config())
+
+        screenshot_calls: list[str] = []
+        show_calls: list[int] = []
+
+        class ShowMockPlotter:
+            window_size = (800, 600)
+
+            def add_mesh(self, mesh, **kwargs):
+                pass
+
+            def add_point_labels(self, points, labels, **kwargs):
+                pass
+
+            def add_text(self, *args, **kwargs):
+                pass
+
+            def add_legend(self, *args, **kwargs):
+                pass
+
+            def screenshot(self, path):
+                screenshot_calls.append(path)
+
+            def show(self):
+                show_calls.append(1)
+
+            def __getattr__(self, name):
+                def _noop(*args, **kwargs):
+                    pass
+                return _noop
+
+        class ShowMockPyVista:
+            def Plotter(self, **kwargs):
+                return ShowMockPlotter()
+
+            @staticmethod
+            def PolyData(points):
+                class MockPolyData:
+                    def __init__(self, pts):
+                        self.points = pts
+                        self.center = [0.5, 0.5, 0.0] if len(pts) > 0 else [0.0, 0.0, 0.0]
+                        self.bounds = [[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]
+
+                return MockPolyData(points)
+
+            @staticmethod
+            def Box(bounds):
+                class MockBox:
+                    def __init__(self):
+                        self.bounds = bounds
+                return MockBox()
+
+        monkeypatch.setitem(sys.modules, "pyvista", ShowMockPyVista())
+
+        viz = pv_mod.ConfigVisualizer(cfg, tmp_path, off_screen=False)
+        viz.preview(use_cpp=False)
+
+        assert len(show_calls) == 1
+        assert len(screenshot_calls) == 0
+
+
+class TestCLIScreenshotCommand:
+    """CLI tests for the --screenshot flag."""
+
+    def _write_config(self, path: Path) -> Path:
+        p = path / "config.json"
+        p.write_text(json.dumps(_minimal_fluid_config()))
+        return p
+
+    def test_screenshot_flag_passes_screenshot_path(self, build_temp_path):
+        """--screenshot FILE should pass screenshot_path to visualizer.preview()."""
+        cfg = self._write_config(build_temp_path)
+        mock_pv = MagicMock()
+        fake_visualizer = MagicMock()
+
+        with patch.dict(sys.modules, {"pyvista": mock_pv}):
+            with patch(
+                "sphinxsim.visualization.preview.ConfigVisualizer",
+                return_value=fake_visualizer,
+            ) as MockViz:
+                rc = main(["preview", str(cfg), "--screenshot", "output.png"])
+
+        assert rc == 0
+        fake_visualizer.preview.assert_called_once_with(use_cpp=True, screenshot_path="output.png")
+
+    def test_screenshot_short_flag_passes_screenshot_path(self, build_temp_path):
+        """-s FILE should pass screenshot_path to visualizer.preview()."""
+        cfg = self._write_config(build_temp_path)
+        mock_pv = MagicMock()
+        fake_visualizer = MagicMock()
+
+        with patch.dict(sys.modules, {"pyvista": mock_pv}):
+            with patch(
+                "sphinxsim.visualization.preview.ConfigVisualizer",
+                return_value=fake_visualizer,
+            ):
+                rc = main(["preview", str(cfg), "-s", "out.png"])
+
+        assert rc == 0
+        fake_visualizer.preview.assert_called_once_with(use_cpp=True, screenshot_path="out.png")
+
+    def test_screenshot_implies_off_screen(self, build_temp_path):
+        """--screenshot should cause ConfigVisualizer to be constructed with off_screen=True."""
+        cfg = self._write_config(build_temp_path)
+        mock_pv = MagicMock()
+        fake_visualizer = MagicMock()
+
+        with patch.dict(sys.modules, {"pyvista": mock_pv}):
+            with patch(
+                "sphinxsim.visualization.preview.ConfigVisualizer",
+                return_value=fake_visualizer,
+            ) as MockViz:
+                rc = main(["preview", str(cfg), "--screenshot", "shot.png"])
+
+        assert rc == 0
+        _, kwargs = MockViz.call_args
+        assert kwargs.get("off_screen") is True
+
+    def test_no_screenshot_does_not_force_off_screen(self, build_temp_path):
+        """Without --screenshot, off_screen should remain False (unless --off-screen is given)."""
+        cfg = self._write_config(build_temp_path)
+        mock_pv = MagicMock()
+        fake_visualizer = MagicMock()
+
+        with patch.dict(sys.modules, {"pyvista": mock_pv}):
+            with patch(
+                "sphinxsim.visualization.preview.ConfigVisualizer",
+                return_value=fake_visualizer,
+            ) as MockViz:
+                rc = main(["preview", str(cfg)])
+
+        assert rc == 0
+        _, kwargs = MockViz.call_args
+        assert kwargs.get("off_screen") is False
+
+
+class TestShellScreenshot:
+    """Shell mode tests for the --screenshot flag."""
+
+    def _write_config(self, path: Path) -> tuple[Path, str]:
+        p = path / "config.json"
+        p.write_text(json.dumps(_minimal_fluid_config()))
+        rel = f"pytest-temp/{path.name}/config.json"
+        return p, rel
+
+    def test_shell_screenshot_passes_screenshot_path(self, build_temp_path):
+        """Shell mode: 'preview --screenshot FILE' should pass screenshot_path to preview()."""
+        _, rel = self._write_config(build_temp_path)
+        fake_visualizer = MagicMock()
+
+        inputs = [f"load {rel}", "preview --screenshot shell_out.png", "exit"]
+        with patch.dict(sys.modules, {"pyvista": MagicMock()}):
+            with patch(
+                "sphinxsim.visualization.preview.ConfigVisualizer",
+                return_value=fake_visualizer,
+            ):
+                with patch("builtins.input", side_effect=inputs):
+                    rc = main(["shell"])
+
+        assert rc == 0
+        fake_visualizer.preview.assert_called_once_with(use_cpp=True, screenshot_path="shell_out.png")
+
+    def test_shell_screenshot_short_flag(self, build_temp_path):
+        """Shell mode: 'preview -s FILE' should pass screenshot_path to preview()."""
+        _, rel = self._write_config(build_temp_path)
+        fake_visualizer = MagicMock()
+
+        inputs = [f"load {rel}", "preview -s short.png", "exit"]
+        with patch.dict(sys.modules, {"pyvista": MagicMock()}):
+            with patch(
+                "sphinxsim.visualization.preview.ConfigVisualizer",
+                return_value=fake_visualizer,
+            ):
+                with patch("builtins.input", side_effect=inputs):
+                    rc = main(["shell"])
+
+        assert rc == 0
+        fake_visualizer.preview.assert_called_once_with(use_cpp=True, screenshot_path="short.png")


### PR DESCRIPTION
This pull request introduces a new screenshot feature to the SPHinXsim visualization framework, allowing users to save a rendered preview as an image file instead of opening an interactive window. The implementation includes CLI, shell, and API support for the new `--screenshot`/`-s` flag, updates to documentation, and enhancements to annotation and rendering conventions. These changes improve usability for headless environments, automated testing, and documentation workflows.

**Screenshot feature and CLI integration:**
- Added support for `--screenshot FILE`/`-s FILE` in both the CLI and interactive shell, enabling users to save a screenshot of the configuration preview directly to a file. This flag automatically enables off-screen rendering and is available in both direct CLI invocations and shell mode. [[1]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R895-R900) [[2]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R709-R724) [[3]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6L416-R430) [[4]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R402-R406) [[5]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6L515-R522) [[6]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R562) [[7]](diffhunk://#diff-db1edc34e2669e38a73d617574cd04b8790a911cc42f5033d40b7e5903fcef27R81) [[8]](diffhunk://#diff-db1edc34e2669e38a73d617574cd04b8790a911cc42f5033d40b7e5903fcef27R201) [[9]](diffhunk://#diff-db1edc34e2669e38a73d617574cd04b8790a911cc42f5033d40b7e5903fcef27R267)

**Visualization framework and annotation improvements:**
- Documented and codified conventions for rendering, annotation, body constraints, observer visualization, and color palette in a new skill guidance file (`.github/skills/visualization_framework/SKILL.md`). This formalizes best practices and testing patterns for visualization changes.
- Added new annotation helpers: `observer_label` and `body_constraint_label` in `annotations.py`, supporting more robust and consistent labeling of observers and body constraints in visualizations. [[1]](diffhunk://#diff-64087d3754129c688f2f94e054d9d8c901e09bb576416dabc60b42b5920c5d95R88-R125) [[2]](diffhunk://#diff-64087d3754129c688f2f94e054d9d8c901e09bb576416dabc60b42b5920c5d95R13-R15)

**Rendering and API changes:**
- Updated `ConfigVisualizer.preview()` to accept a new `screenshot_path` parameter. When set, this saves a screenshot to the specified file and skips opening an interactive window, ensuring headless operation. [[1]](diffhunk://#diff-db912d8e4b8060d1382544609f6a27240a523776d364cd86778649d9470a545aR236) [[2]](diffhunk://#diff-db912d8e4b8060d1382544609f6a27240a523776d364cd86778649d9470a545aR247-R250) [[3]](diffhunk://#diff-db912d8e4b8060d1382544609f6a27240a523776d364cd86778649d9470a545aL261-R271) [[4]](diffhunk://#diff-db912d8e4b8060d1382544609f6a27240a523776d364cd86778649d9470a545aR292-R294)
- Added semantic color constants for observers and constraints in `preview.py` for consistent visual representation. [[1]](diffhunk://#diff-db912d8e4b8060d1382544609f6a27240a523776d364cd86778649d9470a545aR51-R52) [[2]](diffhunk://#diff-db912d8e4b8060d1382544609f6a27240a523776d364cd86778649d9470a545aR33)

**Documentation updates:**
- Expanded CLI and visualization documentation to describe the screenshot feature, its usage, and output, including examples for both CLI and API usage. Documentation now covers new flags, shell command syntax, and expected CLI output. [[1]](diffhunk://#diff-4930ef191171ffe17a17d477fe38a11f97f107e3621c11593191ac05f8e8d1a4R69-R93) [[2]](diffhunk://#diff-4930ef191171ffe17a17d477fe38a11f97f107e3621c11593191ac05f8e8d1a4R111-R116) [[3]](diffhunk://#diff-4930ef191171ffe17a17d477fe38a11f97f107e3621c11593191ac05f8e8d1a4R136) [[4]](diffhunk://#diff-4930ef191171ffe17a17d477fe38a11f97f107e3621c11593191ac05f8e8d1a4R154)

These changes collectively enhance the flexibility and robustness of the visualization framework, making it easier to generate and test visual outputs in a variety of environments.