### PR TITLE
add global information of simulation

### DIFF
--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -283,11 +283,13 @@ class ConfigVisualizer:
         else:
             mode_label = "No C++ geometry"
         dim_label = "2-D" if ndim == 2 else "3-D"
+        sim_type_label = self.config.simulation_type.value.replace("_", " ").title()
+        config_info = f"{dim_label}  •  {sim_type_label}  •  {mode_label}"
         plotter.add_text(
-            f"{title}\n[{dim_label} | {mode_label}]",
-            position="upper_right",
-            font_size=8,
-            color="white",
+            config_info,
+            position="upper_edge",
+            font_size=10,
+            color="cyan",
         )
 
         if screenshot_path is not None:


### PR DESCRIPTION
This pull request makes a small but visible improvement to the simulation preview display. The text overlay in the visualization has been updated to provide clearer and more detailed information about the current simulation configuration.

- Visualization label improvements:
  * The overlay now displays the simulation dimension, simulation type (formatted for readability), and geometry mode, separated by dots, with increased font size and a cyan color for better visibility. The label position has also been adjusted from `upper_right` to `upper_edge`. (`sphinxsim/visualization/preview.py`)