### PR TITLE
Xiangyu/generation blocks

### DIFF
--- a/sphinxsim/cli.py
+++ b/sphinxsim/cli.py
@@ -21,6 +21,7 @@ import argparse
 import json
 import os
 import shlex
+import subprocess
 import sys
 import tempfile
 import warnings
@@ -1195,6 +1196,29 @@ def cmd_shell(args: argparse.Namespace) -> int:
             if config_path is None:
                 print("No config loaded. Run 'load FILE' or 'generate' first.", file=sys.stderr)
                 continue
+
+            # Persistent preview keeps native UI/runtime state alive in-process.
+            # Run simulation in an isolated subprocess to avoid state leakage.
+            if preview_runtime.plotter is not None:
+                resolved_config_path = _resolve_preview_config_path(str(config_path))
+                print("ℹ️ Running simulation in isolated subprocess (persistent preview is active).")
+                try:
+                    completed = subprocess.run(
+                        [sys.executable, "-m", "sphinxsim", "run", str(resolved_config_path)],
+                        cwd=str(resolved_config_path.parent),
+                        capture_output=True,
+                        text=True,
+                    )
+                    if completed.stdout:
+                        print(completed.stdout, end="")
+                    if completed.stderr:
+                        print(completed.stderr, end="", file=sys.stderr)
+                    if completed.returncode != 0:
+                        print(f"❌ Run failed with exit code {completed.returncode}", file=sys.stderr)
+                except Exception as exc:
+                    print(f"❌ Run failed: {exc}", file=sys.stderr)
+                continue
+
             try:
                 cfg, rc = _load_config(config_path)
                 if rc != 0 or cfg is None:

--- a/sphinxsim/cli.py
+++ b/sphinxsim/cli.py
@@ -24,6 +24,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
+import time
 import warnings
 from pathlib import Path
 from typing import Any, Tuple
@@ -638,6 +639,37 @@ class _ShellPreviewRuntime:
             pass
         self.plotter = None
 
+    def pump_ui_events(self) -> None:
+        """Keep the persistent preview responsive while shell work blocks."""
+        if self.plotter is None:
+            return
+
+        try:
+            if self._using_background_plotter:
+                app = getattr(self.plotter, "app", None)
+                if app is not None and hasattr(app, "processEvents"):
+                    app.processEvents()
+                    return
+
+                try:
+                    from PySide6.QtWidgets import QApplication  # type: ignore[import]
+                except Exception:
+                    try:
+                        from PyQt5.QtWidgets import QApplication  # type: ignore[import]
+                    except Exception:
+                        QApplication = None  # type: ignore[misc,assignment]
+
+                if QApplication is not None:
+                    app = QApplication.instance()
+                    if app is not None:
+                        app.processEvents()
+                        return
+
+            if hasattr(self.plotter, "render"):
+                self.plotter.render()
+        except Exception:
+            pass
+
     @staticmethod
     def _set_label_font_size(actor: Any, size: int) -> bool:
         try:
@@ -1201,20 +1233,27 @@ def cmd_shell(args: argparse.Namespace) -> int:
             # Run simulation in an isolated subprocess to avoid state leakage.
             if preview_runtime.plotter is not None:
                 resolved_config_path = _resolve_preview_config_path(str(config_path))
-                print("ℹ️ Running simulation in isolated subprocess (persistent preview is active).")
+                print(
+                    "ℹ️ Running simulation in isolated subprocess (persistent preview is active).",
+                    flush=True,
+                )
                 try:
-                    completed = subprocess.run(
+                    env = os.environ.copy()
+                    env.setdefault("PYTHONUNBUFFERED", "1")
+
+                    process = subprocess.Popen(
                         [sys.executable, "-m", "sphinxsim", "run", str(resolved_config_path)],
                         cwd=str(resolved_config_path.parent),
-                        capture_output=True,
-                        text=True,
+                        env=env,
                     )
-                    if completed.stdout:
-                        print(completed.stdout, end="")
-                    if completed.stderr:
-                        print(completed.stderr, end="", file=sys.stderr)
-                    if completed.returncode != 0:
-                        print(f"❌ Run failed with exit code {completed.returncode}", file=sys.stderr)
+                    while True:
+                        preview_runtime.pump_ui_events()
+                        return_code = process.poll()
+                        if return_code is not None:
+                            break
+                        time.sleep(0.05)
+                    if return_code != 0:
+                        print(f"❌ Run failed with exit code {return_code}", file=sys.stderr)
                 except Exception as exc:
                     print(f"❌ Run failed: {exc}", file=sys.stderr)
                 continue

--- a/sphinxsim/config/schemas.py
+++ b/sphinxsim/config/schemas.py
@@ -351,6 +351,7 @@ class RelaxationBodyConfig(BaseModel):
 
 class ParticleGenerationBodyConfig(BaseModel):
     name: str = Field(..., min_length=1)
+    blocks: List[str] = Field(default_factory=list)
     solid_body: Optional[dict] = None
     relaxation: Optional[RelaxationBodyConfig] = None
 
@@ -1003,6 +1004,12 @@ class SimulationConfig(BaseModel):
                     raise ValueError(
                         f"particle_generation body '{body.name}' must match a shape name in geometries.shapes"
                     )
+                for block_name in body.blocks:
+                    if block_name not in oriented_box_names:
+                        raise ValueError(
+                            "particle_generation body blocks entries must reference existing "
+                            "geometries.oriented_boxes names"
+                        )
             for c in self.particle_generation.settings.relaxation_constraints:
                 if c.body_name not in shape_names:
                     raise ValueError(

--- a/sphinxsim/config/schemas.py
+++ b/sphinxsim/config/schemas.py
@@ -66,7 +66,7 @@ class MultiPolygonPrimitiveType(str, Enum):
 
 
 class OrientedBoxType(str, Enum):
-    IN_OUTLET = "in_outlet"
+    BOUNDARY = "boundary"
     REGION = "region"
 
 
@@ -273,9 +273,9 @@ class OrientedBoxConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_oriented_box(self) -> "OrientedBoxConfig":
-        if self.type == OrientedBoxType.IN_OUTLET:
+        if self.type == OrientedBoxType.BOUNDARY:
             if self.center is None or self.normal is None or self.radius is None:
-                raise ValueError("in_outlet oriented_box requires center, normal and radius")
+                raise ValueError("boundary oriented_box requires center, normal and radius")
         elif self.type == OrientedBoxType.REGION:
             if not self.primitive and (self.half_size is None or self.transform is None):
                 raise ValueError("region oriented_box requires primitive or half_size and transform")

--- a/sphinxsim/sph_simulation/common_builder/geometry_builder.cpp
+++ b/sphinxsim/sph_simulation/common_builder/geometry_builder.cpp
@@ -382,7 +382,7 @@ GeometricShapeBox GeometryBuilder::addOrientedBox(
     const std::string name = config.at("name").get<std::string>();
     const std::string type = config.at("type").get<std::string>();
 
-    if (type == "in_outlet")
+    if (type == "boundary")
     {
         Vecd center = scaling_config.jsonToVecd(config.at("center"), "Length");
         Vecd normal = scaling_config.jsonToVecd(config.at("normal"), "Dimensionless");

--- a/sphinxsim/sph_simulation/dynamics_builder/fluid_dynamics/fluid_dynamics_builder.hpp
+++ b/sphinxsim/sph_simulation/dynamics_builder/fluid_dynamics/fluid_dynamics_builder.hpp
@@ -55,6 +55,7 @@ BaseDynamics<void> &FluidDynamicsBuilder::buildDensityRegularization(
                 std::cout << "- Too large: overlapped bodies" << std::endl;
                 std::cout << "- Too small: insufficient resolution due to thin layer" << std::endl;
                 std::cout << "------------------------------------------------------------" << std::endl;
+                exit(1);
             } });
 
     auto &density_regularization = method_container.addParticleDynamicsGroup();

--- a/sphinxsim/sph_simulation/particle_generation/particle_generation.cpp
+++ b/sphinxsim/sph_simulation/particle_generation/particle_generation.cpp
@@ -183,9 +183,17 @@ void ParticleGeneration ::addAllBodies(
         {
             common_body_config.is_solid_body_ = true;
         }
-
-        real_body.generateParticles<BaseParticles, Lattice>();
         bodies_config_.all_bodies_.push_back(common_body_config);
+
+        StdVec<OrientedBox *> blocks;
+        if (bd.contains("blocks"))
+        {
+            for (const auto &block : bd.at("blocks"))
+            {
+                blocks.push_back(&config_manager.getEntity<OrientedBox>(block.get<std::string>()));
+            }
+        }
+        real_body.generateParticles<BaseParticles, Lattice>(blocks);
     }
 }
 //=================================================================================================//

--- a/sphinxsim/sphinxsys/src/for_2D_build/particle_generator/particle_generator_lattice_2d.cpp
+++ b/sphinxsim/sphinxsys/src/for_2D_build/particle_generator/particle_generator_lattice_2d.cpp
@@ -17,9 +17,11 @@ void ParticleGenerator<BaseParticles, Lattice>::prepareGeometricData()
     for (int i = 0; i < number_of_lattices[0]; ++i)
         for (int j = 0; j < number_of_lattices[1]; ++j)
         {
-            Vecd particle_position = mesh.CellPositionFromIndex(Arrayi(i, j));
-            if (initial_shape_.checkContain(particle_position))
-                addPositionAndVolumetricMeasure(particle_position, particle_volume);
+            Vecd position = mesh.CellPositionFromIndex(Arrayi(i, j));
+            if (initial_shape_.checkContain(position) && !checkBlocks(position))
+            {
+                addPositionAndVolumetricMeasure(position, particle_volume);
+            }
         }
 }
 //=================================================================================================//
@@ -32,8 +34,8 @@ void ParticleGenerator<SurfaceParticles, Lattice>::prepareGeometricData()
     for (int i = 0; i < number_of_lattices[0]; ++i)
         for (int j = 0; j < number_of_lattices[1]; ++j)
         {
-            Vecd particle_position = mesh.CellPositionFromIndex(Arrayi(i, j));
-            if (initial_shape_.checkContain(particle_position))
+            Vecd position = mesh.CellPositionFromIndex(Arrayi(i, j));
+            if (initial_shape_.checkContain(position))
             {
                 all_cells_++;
                 total_volume_ += lattice_spacing_ * lattice_spacing_;
@@ -55,15 +57,15 @@ void ParticleGenerator<SurfaceParticles, Lattice>::prepareGeometricData()
     for (int i = 0; i < number_of_lattices[0]; ++i)
         for (int j = 0; j < number_of_lattices[1]; ++j)
         {
-            Vecd particle_position = mesh.CellPositionFromIndex(Arrayi(i, j));
-            if (initial_shape_.checkContain(particle_position))
+            Vecd position = mesh.CellPositionFromIndex(Arrayi(i, j));
+            if (initial_shape_.checkContain(position))
             {
                 Real random_real = unif(rng);
                 // If the random_real is smaller than the interval, add a particle, only if we haven't reached the max. number of particles
                 if (random_real <= interval && base_particles_.TotalRealParticles() < planned_number_of_particles_)
                 {
-                    addPositionAndVolumetricMeasure(particle_position, avg_particle_volume_ / thickness_);
-                    addSurfaceProperties(initial_shape_.findNormalDirection(particle_position), thickness_);
+                    addPositionAndVolumetricMeasure(position, avg_particle_volume_ / thickness_);
+                    addSurfaceProperties(initial_shape_.findNormalDirection(position), thickness_);
                 }
             }
         }

--- a/sphinxsim/sphinxsys/src/for_3D_build/particle_generator/particle_generator_lattice_3d.cpp
+++ b/sphinxsim/sphinxsys/src/for_3D_build/particle_generator/particle_generator_lattice_3d.cpp
@@ -18,9 +18,9 @@ void ParticleGenerator<BaseParticles, Lattice>::prepareGeometricData()
         for (int j = 0; j < number_of_lattices[1]; ++j)
             for (int k = 0; k < number_of_lattices[2]; ++k)
             {
-                Vecd particle_position = mesh.CellPositionFromIndex(Arrayi(i, j, k));
-                if (initial_shape_.checkContain(particle_position))
-                    addPositionAndVolumetricMeasure(particle_position, particle_volume);
+                Vecd position = mesh.CellPositionFromIndex(Arrayi(i, j, k));
+                if (initial_shape_.checkContain(position) && !checkBlocks(position))
+                    addPositionAndVolumetricMeasure(position, particle_volume);
             }
 }
 //=================================================================================================//
@@ -34,8 +34,8 @@ void ParticleGenerator<SurfaceParticles, Lattice>::prepareGeometricData()
         for (int j = 0; j < number_of_lattices[1]; ++j)
             for (int k = 0; k < number_of_lattices[2]; ++k)
             {
-                Vecd particle_position = mesh.CellPositionFromIndex(Arrayi(i, j, k));
-                if (initial_shape_.checkContain(particle_position))
+                Vecd position = mesh.CellPositionFromIndex(Arrayi(i, j, k));
+                if (initial_shape_.checkContain(position))
                 {
                     all_cells_++;
                     total_volume_ += lattice_spacing_ * lattice_spacing_ * lattice_spacing_;
@@ -58,15 +58,15 @@ void ParticleGenerator<SurfaceParticles, Lattice>::prepareGeometricData()
         for (int j = 0; j < number_of_lattices[1]; ++j)
             for (int k = 0; k < number_of_lattices[2]; ++k)
             {
-                Vecd particle_position = mesh.CellPositionFromIndex(Arrayi(i, j, k));
-                if (initial_shape_.checkContain(particle_position))
+                Vecd position = mesh.CellPositionFromIndex(Arrayi(i, j, k));
+                if (initial_shape_.checkContain(position))
                 {
                     Real random_real = uniform_distr(rng);
                     // If the random_real is smaller than the interval, add a particle, only if we haven't reached the max. number of particles.
                     if (random_real <= interval && base_particles_.TotalRealParticles() < planned_number_of_particles_)
                     {
-                        addPositionAndVolumetricMeasure(particle_position, avg_particle_volume_ / thickness_);
-                        addSurfaceProperties(initial_shape_.findNormalDirection(particle_position), thickness_);
+                        addPositionAndVolumetricMeasure(position, avg_particle_volume_ / thickness_);
+                        addSurfaceProperties(initial_shape_.findNormalDirection(position), thickness_);
                     }
                 }
             }

--- a/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.cpp
+++ b/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.cpp
@@ -20,13 +20,14 @@ GeneratingMethod<Lattice>::GeneratingMethod(SPHBody &sph_body)
 }
 //=================================================================================================//
 ParticleGenerator<BaseParticles, Lattice>::
-    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, Shape &target_shape)
+    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles,
+                      Shape &target_shape, StdVec<OrientedBox *> blocks)
     : ParticleGenerator<BaseParticles>(sph_body, base_particles),
-      GeneratingMethod<Lattice>(sph_body), target_shape_(target_shape) {}
+      GeneratingMethod<Lattice>(sph_body), target_shape_(target_shape), blocks_(blocks) {}
 //=================================================================================================//
 ParticleGenerator<BaseParticles, Lattice>::
-    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles)
-    : ParticleGenerator(sph_body, base_particles, sph_body.getInitialShape()) {}
+    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, StdVec<OrientedBox *> blocks)
+    : ParticleGenerator(sph_body, base_particles, sph_body.getInitialShape(), blocks) {}
 //=================================================================================================//
 void ParticleGenerator<BaseParticles, Lattice>::
     addPositionAndVolumetricMeasure(const Vecd &position, Real volume)
@@ -38,6 +39,16 @@ void ParticleGenerator<BaseParticles, Lattice>::
         ParticleGenerator<BaseParticles>::addPositionAndVolumetricMeasure(
             position, volume / local_particle_volume_ratio);
     }
+}
+//=================================================================================================//
+bool ParticleGenerator<BaseParticles, Lattice>::checkBlocks(const Vecd &position)
+{
+    bool is_blocked = false;
+    for (OrientedBox *block : blocks_)
+    {
+        is_blocked = !is_blocked && block->checkLowerBound(position);
+    }
+    return is_blocked;
 }
 //=================================================================================================//
 ParticleGenerator<SurfaceParticles, Lattice>::

--- a/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.h
+++ b/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.h
@@ -38,6 +38,7 @@ namespace SPH
 class Shape;
 class AdaptiveByShape;
 class SurfaceParticles;
+class OrientedBox;
 
 template <> // Base class for generating particles from lattice positions
 class GeneratingMethod<Lattice>
@@ -58,14 +59,18 @@ class ParticleGenerator<BaseParticles, Lattice>
     : public ParticleGenerator<BaseParticles>, public GeneratingMethod<Lattice>
 {
   public:
-    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, Shape &target_shape);
-    explicit ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles);
+    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, Shape &target_shape,
+                      StdVec<OrientedBox *> blocks = StdVec<OrientedBox *>{});
+    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles,
+                      StdVec<OrientedBox *> blocks = StdVec<OrientedBox *>{});
     virtual ~ParticleGenerator() {};
     virtual void prepareGeometricData() override;
 
   protected:
     Shape &target_shape_;
+    StdVec<OrientedBox *> blocks_;
     virtual void addPositionAndVolumetricMeasure(const Vecd &position, Real volume) override;
+    bool checkBlocks(const Vecd &position);
 };
 
 template <> // For generating surface particles from lattice positions using reduced order approach

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -697,7 +697,7 @@ class ConfigVisualizer:
             if mesh is None:
                 continue
 
-            colour = _INLET_OUTLET_COLOUR if ob.type.value == "in_outlet" else _REGION_COLOUR
+            colour = _INLET_OUTLET_COLOUR if ob.type.value == "boundary" else _REGION_COLOUR
             plotter.add_mesh(
                 mesh,
                 color=colour,

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -23,7 +23,8 @@ a clear install hint.
 
 from __future__ import annotations
 
-import os
+import json
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -342,14 +343,51 @@ class ConfigVisualizer:
             color="cyan",
         )
 
+    def _runtime_config_payload(self) -> dict[str, Any]:
+        """Return a runtime payload with input paths resolved from config dir."""
+        payload = self.config.model_dump(exclude_none=True)
+        if self.config_path is None:
+            return payload
+
+        config_dir = self.config_path.parent
+        geometries = payload.get("geometries", {})
+        shapes = geometries.get("shapes", [])
+        if not isinstance(shapes, list):
+            return payload
+
+        def _absolutize(path_value: Any) -> Any:
+            if not isinstance(path_value, str) or not path_value:
+                return path_value
+            path = Path(path_value)
+            if path.is_absolute():
+                return str(path)
+            return str((config_dir / path).resolve())
+
+        for shape in shapes:
+            if not isinstance(shape, dict):
+                continue
+            if shape.get("type") == "triangle_mesh":
+                shape["file_name"] = _absolutize(shape.get("file_name"))
+            if shape.get("type") == "multipolygon":
+                polygons = shape.get("polygons", [])
+                if not isinstance(polygons, list):
+                    continue
+                for polygon in polygons:
+                    if not isinstance(polygon, dict):
+                        continue
+                    if polygon.get("type") == "data_file":
+                        polygon["file_name"] = _absolutize(polygon.get("file_name"))
+
+        return payload
+
     def _try_build_geometries(self, ndim: int, with_particles: bool = False) -> Path | None:
         """Run buildGeometries() and return the VTP output directory, or None.
 
-        Uses ``self.config_path`` directly as the C++ config input so the
-        original JSON file is the single source of truth. Geometry generation
-        uses the lightweight ``GeometryBuilder`` class. If VTPs are not
-        produced, the builder-provided ``getShapeBounds()`` cache is reused
-        for preview rendering.
+        Writes a temporary runtime JSON derived from ``self.config`` where
+        relative input file paths are resolved from ``self.config_path``.
+        Geometry generation uses the lightweight ``GeometryBuilder`` class.
+        If VTPs are not produced, the builder-provided ``getShapeBounds()``
+        cache is reused for preview rendering.
         """
         if self.config_path is None:
             self._shape_bounds_cache = None
@@ -360,25 +398,33 @@ class ConfigVisualizer:
         except ImportError as exc:
             raise ImportError(str(exc)) from None
 
-        vtp_output_dir = self.project_root / ".build-temp" / "preview_geometry"
+        vtp_output_dir = self.project_root / ".build-temp" / "test_simulation"
         vtp_output_dir.mkdir(parents=True, exist_ok=True)
         output_subdir = vtp_output_dir / "output"
         for stale_dir in (vtp_output_dir, output_subdir):
             if not stale_dir.is_dir():
                 continue
-            # This directory is reserved for preview, so clean stale VTPs.
-            for stale_vtp in stale_dir.glob("*.vtp"):
+            # In shared output mode, only clean preview geometry meshes.
+            for stale_vtp in stale_dir.glob("Shape*.vtp"):
                 try:
                     stale_vtp.unlink()
                 except OSError:
                     pass
 
-        original_dir = os.getcwd()
-        # Change to the config file's directory so that relative paths in the
-        # JSON (e.g. STL file_path for 3-D triangle_mesh shapes) resolve correctly.
-        os.chdir(self.config_path.parent)
+        runtime_config_path: Path | None = None
         try:
-            builder = sph.GeometryBuilder(str(self.config_path))
+            tmp = tempfile.NamedTemporaryFile(
+                mode="w",
+                suffix=".json",
+                prefix="sphinxsim_preview_",
+                delete=False,
+                dir=str(vtp_output_dir),
+            )
+            json.dump(self._runtime_config_payload(), tmp, indent=2)
+            tmp.close()
+            runtime_config_path = Path(tmp.name)
+
+            builder = sph.GeometryBuilder(str(runtime_config_path))
             builder.resetInOutputRoot(str(vtp_output_dir))
             builder.buildGeometries()
 
@@ -390,7 +436,7 @@ class ConfigVisualizer:
             # Optionally generate particles so preview can overlay the latest
             # body particle clouds if particle_generation is enabled.
             if with_particles and self.config.particle_generation.build_and_run:
-                sim = sph.SPHSimulation(str(self.config_path))
+                sim = sph.SPHSimulation(str(runtime_config_path))
                 sim.resetOutputRoot(str(vtp_output_dir), True)
                 sim.buildGeometries()
                 sim.generateParticles()
@@ -398,7 +444,11 @@ class ConfigVisualizer:
             self._shape_bounds_cache = None
             return None
         finally:
-            os.chdir(original_dir)
+            if runtime_config_path is not None:
+                try:
+                    runtime_config_path.unlink()
+                except OSError:
+                    pass
 
         # VTPs land in <vtp_output_dir>/output/
         if output_subdir.is_dir() and any(output_subdir.glob("Shape*.vtp")):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -625,6 +625,37 @@ class TestSimulationConfig:
                 ]
             )
 
+    def test_particle_generation_blocks_accept_existing_oriented_box(self):
+        cfg = _make_minimal_fluid_config(
+            particle_generation={
+                "build_and_run": False,
+                "settings": {
+                    "bodies": [
+                        {"name": "WaterBody", "blocks": ["Inlet"]},
+                        {"name": "WallBoundary", "solid_body": {}},
+                    ],
+                    "relaxation_parameters": {"total_iterations": 1000},
+                },
+            }
+        )
+        assert cfg.particle_generation.settings is not None
+        assert cfg.particle_generation.settings.bodies[0].blocks == ["Inlet"]
+
+    def test_particle_generation_blocks_reject_unknown_oriented_box(self):
+        with pytest.raises(ValidationError, match="blocks entries must reference existing"):
+            _make_minimal_fluid_config(
+                particle_generation={
+                    "build_and_run": False,
+                    "settings": {
+                        "bodies": [
+                            {"name": "WaterBody", "blocks": ["MissingBox"]},
+                            {"name": "WallBoundary", "solid_body": {}},
+                        ],
+                        "relaxation_parameters": {"total_iterations": 1000},
+                    },
+                }
+            )
+
     def test_global_resolution_is_required(self):
         data = _make_minimal_fluid_config().model_dump(mode="json")
         del data["geometries"]["global_resolution"]

--- a/tests/test_simulation/test_2d_simulation/data/heat_transfer.json
+++ b/tests/test_simulation/test_2d_simulation/data/heat_transfer.json
@@ -50,14 +50,14 @@
     "oriented_boxes": [
       {
         "name": "Inlet",
-        "type": "in_outlet",
+        "type": "boundary",
         "center": [0.0, 0.2],
         "normal": [1.0, 0.0],
         "radius": 0.2
       },
       {
         "name": "Outlet",
-        "type": "in_outlet",
+        "type": "boundary",
         "center": [2.0, 0.2],
         "normal": [-1.0, 0.0],
         "radius": 0.2

--- a/tests/test_simulation/test_2d_simulation/data/multi_phase_mixing.json
+++ b/tests/test_simulation/test_2d_simulation/data/multi_phase_mixing.json
@@ -74,6 +74,13 @@
         "name": "Emitter",
         "type": "region",
         "primitive": "EmitterBox"
+      },
+      {
+        "name": "FillLevel",
+        "type": "boundary",
+        "center": [1.0, 0.4],
+        "normal": [0.0, -1.0],
+        "radius": 1.0
       }
     ]
   },
@@ -82,7 +89,8 @@
     "settings": {
       "bodies": [
         {
-          "name": "MultiPhaseBody"
+          "name": "MultiPhaseBody",
+          "blocks": ["FillLevel"]
         },
         {
           "name": "WallBoundary",

--- a/tests/test_simulation/test_2d_simulation/data/t_junction.json
+++ b/tests/test_simulation/test_2d_simulation/data/t_junction.json
@@ -83,21 +83,21 @@
     "oriented_boxes": [
       {
         "name": "Outlet",
-        "type": "in_outlet",
+        "type": "boundary",
         "center": [0.0, 0.0],
         "normal": [1.0, 0.0],
         "radius": 0.05
       },
       {
         "name": "UpperInlet",
-        "type": "in_outlet",
+        "type": "boundary",
         "center": [0.175, 0.15],
         "normal": [0.0, -1.0],
         "radius": 0.025
       },
       {
         "name": "LowerInlet",
-        "type": "in_outlet",
+        "type": "boundary",
         "center": [0.175, -0.15],
         "normal": [0.0, 1.0],
         "radius": 0.025

--- a/tests/test_simulation/test_3d_simulation/data/t_pipe.json
+++ b/tests/test_simulation/test_3d_simulation/data/t_pipe.json
@@ -38,21 +38,21 @@
     "oriented_boxes": [
       {
         "name": "Inlet",
-        "type": "in_outlet",
+        "type": "boundary",
         "center": [-0.01, 0.0, 0.0],
         "normal": [1.0, 0.0, 0.0],
         "radius": 0.00185
       },
       {
         "name": "UpperOutlet",
-        "type": "in_outlet",
+        "type": "boundary",
         "center": [0.005, 0.03, 0.0],
         "normal": [0.0, -1.0, 0.0],
         "radius": 0.00145
       },
       {
         "name": "LowerOutlet",
-        "type": "in_outlet",
+        "type": "boundary",
         "center": [0.005, -0.03, 0.0],
         "normal": [0.0, 1.0, 0.0],
         "radius": 0.00121

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -52,7 +52,7 @@ def _minimal_fluid_config() -> dict:
             "oriented_boxes": [
                 {
                     "name": "Inlet",
-                    "type": "in_outlet",
+                    "type": "boundary",
                     "center": [0.0, 0.1],
                     "normal": [1.0, 0.0],
                     "radius": 0.1,
@@ -156,7 +156,7 @@ class TestOrientedBoxLabel:
         ob = fluid_config.geometries.oriented_boxes[0]  # "Inlet"
         label = oriented_box_label(ob, fluid_config)
         assert "Inlet" in label
-        assert "in_outlet" in label
+        assert "boundary" in label
 
     def test_label_includes_bc_type(self, fluid_config):
         from sphinxsim.visualization.annotations import oriented_box_label


### PR DESCRIPTION
This pull request introduces several significant improvements and changes across the codebase, primarily focused on enhancing simulation preview isolation, improving particle generation logic with support for "blocks," and updating configuration terminology for clarity and consistency. The most important changes are grouped below.

**Simulation Preview Isolation and Responsiveness:**

* The CLI now runs simulations in an isolated subprocess when the persistent preview is active, preventing state leakage between the preview and simulation runs. A new `pump_ui_events` method keeps the preview responsive during blocking shell operations. (`sphinxsim/cli.py`) [[1]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R24-R27) [[2]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R642-R672) [[3]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R1231-R1260)

**Particle Generation and Geometry Handling:**

* The particle generator for `BaseParticles, Lattice` now accepts a list of "block" `OrientedBox` objects, and particles are only generated in regions not covered by these blocks. The logic for checking blocks is implemented in the new `checkBlocks` method, and the relevant constructors and method signatures are updated accordingly. (`sphinxsim/sph_simulation/particle_generation/particle_generation.cpp`, `sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.cpp`, `sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.h`) [[1]](diffhunk://#diff-90fb6d373ace4ebd1d16f15d82bc6357c2cbf749e75d7ba464615a518f6e8397L186-R196) [[2]](diffhunk://#diff-af4e17401d0cf82dbddd3ffb5e3272702ddde7fc960491b0cd06e51271dc4d81L23-R30) [[3]](diffhunk://#diff-af4e17401d0cf82dbddd3ffb5e3272702ddde7fc960491b0cd06e51271dc4d81R44-R53) [[4]](diffhunk://#diff-7be23bf5d69fa74c044f194b63c0770e9e8ca6074712c129d4bbcf231d7db229R41) [[5]](diffhunk://#diff-7be23bf5d69fa74c044f194b63c0770e9e8ca6074712c129d4bbcf231d7db229L61-R73)
* The 2D and 3D lattice particle generators are updated to use the new block exclusion logic, ensuring particles are not placed inside block regions. (`sphinxsim/sphinxsys/src/for_2D_build/particle_generator/particle_generator_lattice_2d.cpp`, `sphinxsim/sphinxsys/src/for_3D_build/particle_generator/particle_generator_lattice_3d.cpp`) [[1]](diffhunk://#diff-ac98d344b1aab1bf74b5482b58a30bd7317e45e53e08ee1b2d8531eb3624a341L20-R24) [[2]](diffhunk://#diff-ac98d344b1aab1bf74b5482b58a30bd7317e45e53e08ee1b2d8531eb3624a341L35-R38) [[3]](diffhunk://#diff-ac98d344b1aab1bf74b5482b58a30bd7317e45e53e08ee1b2d8531eb3624a341L58-R68) [[4]](diffhunk://#diff-d2002abaca1936f6e720eb6b7010a3f1ef62580fb5888a12025ba2872fdd8135L21-R23) [[5]](diffhunk://#diff-d2002abaca1936f6e720eb6b7010a3f1ef62580fb5888a12025ba2872fdd8135L37-R38) [[6]](diffhunk://#diff-d2002abaca1936f6e720eb6b7010a3f1ef62580fb5888a12025ba2872fdd8135L61-R69)

**Configuration and Schema Updates:**

* The `OrientedBoxType` enum and related validation logic are updated to use `"boundary"` instead of `"in_outlet"` for improved clarity and consistency. This change is reflected in both the Python and C++ code handling geometry configuration. (`sphinxsim/config/schemas.py`, `sphinxsim/sph_simulation/common_builder/geometry_builder.cpp`) [[1]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289L69-R69) [[2]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289L276-R278) [[3]](diffhunk://#diff-a919ad3f389fa0aea84a720124a1777080bf1fa2c2cc182bc04f25a1c5702331L385-R385)

**Preview and Geometry File Handling:**

* The preview system now generates a runtime configuration payload with all relative input file paths resolved to absolute paths, ensuring correct file references during geometry generation. (`sphinxsim/visualization/preview.py`) [[1]](diffhunk://#diff-db912d8e4b8060d1382544609f6a27240a523776d364cd86778649d9470a545aL26-R27) [[2]](diffhunk://#diff-db912d8e4b8060d1382544609f6a27240a523776d364cd86778649d9470a545aR346-R390)

**Other Improvements:**

* The fluid dynamics builder now exits with a failure code if density regularization checks fail, improving error handling during simulation setup. (`sphinxsim/sph_simulation/dynamics_builder/fluid_dynamics/fluid_dynamics_builder.hpp`)