### PR TITLE
Xiangyu/generate inserts

### DIFF
--- a/sphinxsim/config/schemas.py
+++ b/sphinxsim/config/schemas.py
@@ -345,15 +345,44 @@ class GeometriesConfig(BaseModel):
 
 
 class RelaxationBodyConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     level_set: Optional[dict] = None
     dependent_bodies: List[str] = Field(default_factory=list)
 
+    @model_validator(mode="after")
+    def _warn_unknown_fields(self) -> "RelaxationBodyConfig":
+        extra = getattr(self, "__pydantic_extra__", None)
+        if extra:
+            warnings.warn(
+                "particle_generation.relaxation contains unknown keys that are preserved: "
+                + ", ".join(sorted(extra.keys())),
+                UserWarning,
+                stacklevel=2,
+            )
+        return self
+
 
 class ParticleGenerationBodyConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     name: str = Field(..., min_length=1)
     blocks: List[str] = Field(default_factory=list)
+    inserts: List[str] = Field(default_factory=list)
     solid_body: Optional[dict] = None
     relaxation: Optional[RelaxationBodyConfig] = None
+
+    @model_validator(mode="after")
+    def _warn_unknown_fields(self) -> "ParticleGenerationBodyConfig":
+        extra = getattr(self, "__pydantic_extra__", None)
+        if extra:
+            warnings.warn(
+                "particle_generation.settings.bodies contains unknown keys that are preserved: "
+                + ", ".join(sorted(extra.keys())),
+                UserWarning,
+                stacklevel=2,
+            )
+        return self
 
 
 class RelaxationParametersConfig(BaseModel):
@@ -367,9 +396,23 @@ class RelaxationConstraintConfig(BaseModel):
 
 
 class ParticleGenerationSettingsConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     bodies: List[ParticleGenerationBodyConfig] = Field(..., min_length=1)
     relaxation_constraints: List[RelaxationConstraintConfig] = Field(default_factory=list)
     relaxation_parameters: RelaxationParametersConfig = Field(default_factory=RelaxationParametersConfig)
+
+    @model_validator(mode="after")
+    def _warn_unknown_fields(self) -> "ParticleGenerationSettingsConfig":
+        extra = getattr(self, "__pydantic_extra__", None)
+        if extra:
+            warnings.warn(
+                "particle_generation.settings contains unknown keys that are preserved: "
+                + ", ".join(sorted(extra.keys())),
+                UserWarning,
+                stacklevel=2,
+            )
+        return self
 
 
 class ParticleGenerationConfig(BaseModel):
@@ -1008,6 +1051,12 @@ class SimulationConfig(BaseModel):
                     if block_name not in oriented_box_names:
                         raise ValueError(
                             "particle_generation body blocks entries must reference existing "
+                            "geometries.oriented_boxes names"
+                        )
+                for insert_name in body.inserts:
+                    if insert_name not in oriented_box_names:
+                        raise ValueError(
+                            "particle_generation body inserts entries must reference existing "
                             "geometries.oriented_boxes names"
                         )
             for c in self.particle_generation.settings.relaxation_constraints:

--- a/sphinxsim/sph_simulation/particle_generation/particle_generation.cpp
+++ b/sphinxsim/sph_simulation/particle_generation/particle_generation.cpp
@@ -193,7 +193,16 @@ void ParticleGeneration ::addAllBodies(
                 blocks.push_back(&config_manager.getEntity<OrientedBox>(block.get<std::string>()));
             }
         }
-        real_body.generateParticles<BaseParticles, Lattice>(blocks);
+
+        StdVec<OrientedBox *> inserts;
+        if (bd.contains("inserts"))
+        {
+            for (const auto &insert : bd.at("inserts"))
+            {
+                inserts.push_back(&config_manager.getEntity<OrientedBox>(insert.get<std::string>()));
+            }
+        }
+        real_body.generateParticles<BaseParticles, Lattice>(blocks, inserts);
     }
 }
 //=================================================================================================//

--- a/sphinxsim/sphinxsys/src/for_2D_build/particle_generator/particle_generator_lattice_2d.cpp
+++ b/sphinxsim/sphinxsys/src/for_2D_build/particle_generator/particle_generator_lattice_2d.cpp
@@ -22,6 +22,10 @@ void ParticleGenerator<BaseParticles, Lattice>::prepareGeometricData()
             {
                 addPositionAndVolumetricMeasure(position, particle_volume);
             }
+            else
+            {
+                addInserts(position, particle_volume);
+            }
         }
 }
 //=================================================================================================//

--- a/sphinxsim/sphinxsys/src/for_3D_build/particle_generator/particle_generator_lattice_3d.cpp
+++ b/sphinxsim/sphinxsys/src/for_3D_build/particle_generator/particle_generator_lattice_3d.cpp
@@ -20,7 +20,13 @@ void ParticleGenerator<BaseParticles, Lattice>::prepareGeometricData()
             {
                 Vecd position = mesh.CellPositionFromIndex(Arrayi(i, j, k));
                 if (initial_shape_.checkContain(position) && !checkBlocks(position))
+                {
                     addPositionAndVolumetricMeasure(position, particle_volume);
+                }
+                else
+                {
+                    addInserts(position, particle_volume);
+                }
             }
 }
 //=================================================================================================//

--- a/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.cpp
+++ b/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.cpp
@@ -20,14 +20,15 @@ GeneratingMethod<Lattice>::GeneratingMethod(SPHBody &sph_body)
 }
 //=================================================================================================//
 ParticleGenerator<BaseParticles, Lattice>::
-    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles,
-                      Shape &target_shape, StdVec<OrientedBox *> blocks)
+    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, Shape &target_shape,
+                      StdVec<OrientedBox *> blocks, StdVec<OrientedBox *> inserts)
     : ParticleGenerator<BaseParticles>(sph_body, base_particles),
-      GeneratingMethod<Lattice>(sph_body), target_shape_(target_shape), blocks_(blocks) {}
+      GeneratingMethod<Lattice>(sph_body), target_shape_(target_shape), blocks_(blocks), inserts_(inserts) {}
 //=================================================================================================//
 ParticleGenerator<BaseParticles, Lattice>::
-    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, StdVec<OrientedBox *> blocks)
-    : ParticleGenerator(sph_body, base_particles, sph_body.getInitialShape(), blocks) {}
+    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles,
+                      StdVec<OrientedBox *> blocks, StdVec<OrientedBox *> inserts)
+    : ParticleGenerator(sph_body, base_particles, sph_body.getInitialShape(), blocks, inserts) {}
 //=================================================================================================//
 void ParticleGenerator<BaseParticles, Lattice>::
     addPositionAndVolumetricMeasure(const Vecd &position, Real volume)
@@ -49,6 +50,17 @@ bool ParticleGenerator<BaseParticles, Lattice>::checkBlocks(const Vecd &position
         is_blocked = !is_blocked && block->checkLowerBound(position);
     }
     return is_blocked;
+}
+//=================================================================================================//
+void ParticleGenerator<BaseParticles, Lattice>::addInserts(const Vecd &position, Real volume)
+{
+    for (OrientedBox *insert : inserts_)
+    {
+        if (insert->checkContain(position))
+        {
+            addPositionAndVolumetricMeasure(position, volume);
+        }
+    }
 }
 //=================================================================================================//
 ParticleGenerator<SurfaceParticles, Lattice>::

--- a/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.h
+++ b/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.h
@@ -60,17 +60,21 @@ class ParticleGenerator<BaseParticles, Lattice>
 {
   public:
     ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, Shape &target_shape,
-                      StdVec<OrientedBox *> blocks = StdVec<OrientedBox *>{});
+                      StdVec<OrientedBox *> blocks = StdVec<OrientedBox *>{},
+                      StdVec<OrientedBox *> inserts = StdVec<OrientedBox *>{});
     ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles,
-                      StdVec<OrientedBox *> blocks = StdVec<OrientedBox *>{});
+                      StdVec<OrientedBox *> blocks = StdVec<OrientedBox *>{},
+                      StdVec<OrientedBox *> inserts = StdVec<OrientedBox *>{});
     virtual ~ParticleGenerator() {};
     virtual void prepareGeometricData() override;
 
   protected:
     Shape &target_shape_;
     StdVec<OrientedBox *> blocks_;
+    StdVec<OrientedBox *> inserts_;
     virtual void addPositionAndVolumetricMeasure(const Vecd &position, Real volume) override;
     bool checkBlocks(const Vecd &position);
+    void addInserts(const Vecd &position, Real volume);
 };
 
 template <> // For generating surface particles from lattice positions using reduced order approach

--- a/sphinxsim/sphinxsys/src/shared/particles/base_particles.cpp
+++ b/sphinxsim/sphinxsys/src/shared/particles/base_particles.cpp
@@ -53,7 +53,7 @@ void BaseParticles::addParticleGroupToWrite(const std::string &name)
     }
     else
     {
-        std::runtime_error("Error: the particle group " + name + " is not registered!");
+        throw std::runtime_error("Error: the particle group " + name + " is not registered!");
     }
 }
 //=================================================================================================//

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -656,6 +656,56 @@ class TestSimulationConfig:
                 }
             )
 
+    def test_particle_generation_inserts_accept_existing_oriented_box(self):
+        cfg = _make_minimal_fluid_config(
+            particle_generation={
+                "build_and_run": False,
+                "settings": {
+                    "bodies": [
+                        {"name": "WaterBody", "inserts": ["Inlet"]},
+                        {"name": "WallBoundary", "solid_body": {}},
+                    ],
+                    "relaxation_parameters": {"total_iterations": 1000},
+                },
+            }
+        )
+        assert cfg.particle_generation.settings is not None
+        assert cfg.particle_generation.settings.bodies[0].inserts == ["Inlet"]
+
+    def test_particle_generation_inserts_reject_unknown_oriented_box(self):
+        with pytest.raises(ValidationError, match="inserts entries must reference existing"):
+            _make_minimal_fluid_config(
+                particle_generation={
+                    "build_and_run": False,
+                    "settings": {
+                        "bodies": [
+                            {"name": "WaterBody", "inserts": ["MissingBox"]},
+                            {"name": "WallBoundary", "solid_body": {}},
+                        ],
+                        "relaxation_parameters": {"total_iterations": 1000},
+                    },
+                }
+            )
+
+    def test_particle_generation_body_unknown_field_warns_and_is_preserved(self):
+        with pytest.warns(UserWarning, match="contains unknown keys that are preserved"):
+            cfg = _make_minimal_fluid_config(
+                particle_generation={
+                    "build_and_run": False,
+                    "settings": {
+                        "bodies": [
+                            {"name": "WaterBody", "unknown_key": ["Inlet"]},
+                            {"name": "WallBoundary", "solid_body": {}},
+                        ],
+                        "relaxation_parameters": {"total_iterations": 1000},
+                    },
+                }
+            )
+
+        dumped = cfg.model_dump(mode="json")
+        assert "unknown_key" in dumped["particle_generation"]["settings"]["bodies"][0]
+        assert dumped["particle_generation"]["settings"]["bodies"][0]["unknown_key"] == ["Inlet"]
+
     def test_global_resolution_is_required(self):
         data = _make_minimal_fluid_config().model_dump(mode="json")
         del data["geometries"]["global_resolution"]

--- a/tests/test_simulation/test_2d_simulation/data/multi_phase_mixing.json
+++ b/tests/test_simulation/test_2d_simulation/data/multi_phase_mixing.json
@@ -3,7 +3,7 @@
     {
       "value": 1.0,
       "name": "Length",
-      "hint": "geometries.shapes[name=MultiPhaseBody].polygons[type=bounding_box].upper_bound"
+      "hint": "geometries.shapes[name=MultiPhaseBody].upper_bound"
     },
     {
       "value": 1.0,
@@ -35,20 +35,9 @@
     "shapes": [
       {
         "name": "MultiPhaseBody",
-        "type": "multipolygon",
-        "polygons": [
-          {
-            "operation": "union",
-            "type": "box",
-            "primitive": "EmitterBox"
-          },
-          {
-            "operation": "union",
-            "type": "bounding_box",
-            "lower_bound": [0.0, 0.0],
-            "upper_bound": [2.0, 0.5]
-          }
-        ]
+        "type": "bounding_box",
+        "lower_bound": [0.0, 0.0],
+        "upper_bound": [2.0, 0.5]
       },
       {
         "name": "WallBoundary",
@@ -90,7 +79,8 @@
       "bodies": [
         {
           "name": "MultiPhaseBody",
-          "blocks": ["FillLevel"]
+          "blocks": ["FillLevel"],
+          "inserts": ["Emitter"]
         },
         {
           "name": "WallBoundary",


### PR DESCRIPTION
This pull request introduces support for "inserts" in particle generation bodies, allowing users to specify additional oriented boxes where particles should be inserted during simulation setup. The changes span configuration schema validation, C++ core logic, and test coverage. Additionally, the PR improves configuration flexibility by allowing unknown fields with warnings, and fixes a minor error handling bug.

**Particle Generation Inserts Support**

* Added an `inserts` field to `ParticleGenerationBodyConfig`, with schema validation to ensure referenced oriented boxes exist. Inserts are now passed from configuration through to the C++ simulation code, where they are handled during particle generation. [[1]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289R348-R386) [[2]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289R1056-R1061) [[3]](diffhunk://#diff-90fb6d373ace4ebd1d16f15d82bc6357c2cbf749e75d7ba464615a518f6e8397L196-R205) [[4]](diffhunk://#diff-af4e17401d0cf82dbddd3ffb5e3272702ddde7fc960491b0cd06e51271dc4d81L23-R31) [[5]](diffhunk://#diff-af4e17401d0cf82dbddd3ffb5e3272702ddde7fc960491b0cd06e51271dc4d81R55-R65) [[6]](diffhunk://#diff-7be23bf5d69fa74c044f194b63c0770e9e8ca6074712c129d4bbcf231d7db229L63-R77) [[7]](diffhunk://#diff-ac98d344b1aab1bf74b5482b58a30bd7317e45e53e08ee1b2d8531eb3624a341R25-R28) [[8]](diffhunk://#diff-d2002abaca1936f6e720eb6b7010a3f1ef62580fb5888a12025ba2872fdd8135R23-R30)

* Added tests to verify that inserts referencing existing oriented boxes are accepted, unknown inserts are rejected, and that unknown fields in body configs are preserved with a warning.

**Configuration Schema Improvements**

* The `RelaxationBodyConfig`, `ParticleGenerationBodyConfig`, and `ParticleGenerationSettingsConfig` now allow extra fields, preserving unknown keys and issuing a warning. This improves forward compatibility and user experience for configuration files. [[1]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289R348-R386) [[2]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289R399-R416)

**Simulation Data and Error Handling**

* Updated a test simulation JSON file to use the new inserts field and simplified the bounding box shape definition. [[1]](diffhunk://#diff-3dcef9d6e411f15814cee31070720d8f5dfe1bc1bc15707b95477a89c51870f9L6-R6) [[2]](diffhunk://#diff-3dcef9d6e411f15814cee31070720d8f5dfe1bc1bc15707b95477a89c51870f9L38-L51) [[3]](diffhunk://#diff-3dcef9d6e411f15814cee31070720d8f5dfe1bc1bc15707b95477a89c51870f9L93-R83)
* Fixed a bug in `base_particles.cpp` where an unregistered particle group now correctly throws a `std::runtime_error`.