### PR TITLE
Xiangyu/axis alignment

### DIFF
--- a/sphinxsim/config/schemas.py
+++ b/sphinxsim/config/schemas.py
@@ -52,6 +52,7 @@ class BodyShapeType(str, Enum):
     EXPANDED_BOX = "expanded_box"
     COMPLEX_SHAPE = "complex_shape"
     MULTIPOLYGON = "multipolygon"
+    CYLINDER = "cylinder"
     TRIANGLE_MESH = "triangle_mesh"
 
 
@@ -214,6 +215,9 @@ class ShapeConfig(BaseModel):
 
     polygons: Optional[List[MultiPolygonEntryConfig]] = None
 
+    radius: Optional[float] = Field(default=None, gt=0)
+    half_height: Optional[float] = Field(default=None, gt=0)
+
     file_name: Optional[str] = None
     translation: Optional[List[float]] = Field(default=None, min_length=3, max_length=3)
     scale: Optional[float] = Field(default=None, gt=0)
@@ -249,6 +253,11 @@ class ShapeConfig(BaseModel):
         if self.type == BodyShapeType.MULTIPOLYGON:
             if not self.polygons:
                 raise ValueError("multipolygon shape requires non-empty polygons")
+            return self
+
+        if self.type == BodyShapeType.CYLINDER:
+            if self.radius is None or self.half_height is None or self.transform is None:
+                raise ValueError("cylinder shape requires radius, half_height and transform")
             return self
 
         if self.type == BodyShapeType.TRIANGLE_MESH:
@@ -369,6 +378,7 @@ class ParticleGenerationBodyConfig(BaseModel):
     name: str = Field(..., min_length=1)
     blocks: List[str] = Field(default_factory=list)
     box_shape_inserts: List[str] = Field(default_factory=list)
+    cylinder_shape_inserts: List[str] = Field(default_factory=list)
     solid_body: Optional[dict] = None
     relaxation: Optional[RelaxationBodyConfig] = None
 
@@ -974,6 +984,7 @@ class SimulationConfig(BaseModel):
             )
 
         shape_names = {shape.name for shape in self.geometries.shapes}
+        shape_types_by_name = {shape.name: shape.type for shape in self.geometries.shapes}
         oriented_box_names = {ab.name for ab in self.geometries.oriented_boxes}
 
         for section_name, bodies in (
@@ -1058,6 +1069,26 @@ class SimulationConfig(BaseModel):
                         raise ValueError(
                             "particle_generation body box_shape_inserts entries must reference existing "
                             "geometries.shapes names"
+                        )
+                    if shape_types_by_name[insert_name] not in (
+                        BodyShapeType.BOX,
+                        BodyShapeType.BOUNDING_BOX,
+                        BodyShapeType.EXPANDED_BOX,
+                    ):
+                        raise ValueError(
+                            "particle_generation body box_shape_inserts entries must reference "
+                            "box-compatible shapes (box, bounding_box, expanded_box)"
+                        )
+                for insert_name in body.cylinder_shape_inserts:
+                    if insert_name not in shape_names:
+                        raise ValueError(
+                            "particle_generation body cylinder_shape_inserts entries must reference existing "
+                            "geometries.shapes names"
+                        )
+                    if shape_types_by_name[insert_name] != BodyShapeType.CYLINDER:
+                        raise ValueError(
+                            "particle_generation body cylinder_shape_inserts entries must reference "
+                            "cylinder shapes"
                         )
             for c in self.particle_generation.settings.relaxation_constraints:
                 if c.body_name not in shape_names:
@@ -1174,6 +1205,8 @@ class SimulationConfig(BaseModel):
         elif dim == 2:
             if any(shape.type == BodyShapeType.TRIANGLE_MESH for shape in self.geometries.shapes):
                 raise ValueError("triangle_mesh shapes are 3D-only; use 2D shapes for 2D configurations")
+            if any(shape.type == BodyShapeType.CYLINDER for shape in self.geometries.shapes):
+                raise ValueError("cylinder shapes are 3D-only; use 2D shapes for 2D configurations")
 
         all_plastic_continuum = bool(self.continuum_bodies) and all(
             body.material.type == MaterialType.PLASTIC_CONTINUUM

--- a/sphinxsim/config/schemas.py
+++ b/sphinxsim/config/schemas.py
@@ -368,7 +368,7 @@ class ParticleGenerationBodyConfig(BaseModel):
 
     name: str = Field(..., min_length=1)
     blocks: List[str] = Field(default_factory=list)
-    inserts: List[str] = Field(default_factory=list)
+    box_shape_inserts: List[str] = Field(default_factory=list)
     solid_body: Optional[dict] = None
     relaxation: Optional[RelaxationBodyConfig] = None
 
@@ -1053,11 +1053,11 @@ class SimulationConfig(BaseModel):
                             "particle_generation body blocks entries must reference existing "
                             "geometries.oriented_boxes names"
                         )
-                for insert_name in body.inserts:
-                    if insert_name not in oriented_box_names:
+                for insert_name in body.box_shape_inserts:
+                    if insert_name not in shape_names:
                         raise ValueError(
-                            "particle_generation body inserts entries must reference existing "
-                            "geometries.oriented_boxes names"
+                            "particle_generation body box_shape_inserts entries must reference existing "
+                            "geometries.shapes names"
                         )
             for c in self.particle_generation.settings.relaxation_constraints:
                 if c.body_name not in shape_names:

--- a/sphinxsim/sph_simulation/common_builder/geometry_builder.cpp
+++ b/sphinxsim/sph_simulation/common_builder/geometry_builder.cpp
@@ -155,6 +155,25 @@ TransformGeometryBox GeometryBuilder::fetch_or_parseBox(
     }
 }
 //=================================================================================================//
+#ifdef SPHINXSYS_3D
+TransformGeometryCylinder GeometryBuilder::fetch_or_parseCylinder(
+    const ScalingConfig &scaling_config, EntityManager &config_manager, const json &config)
+{
+    if (config.contains("primitive"))
+    {
+        return TransformGeometryCylinder(config_manager.getEntity<TransformGeometryCylinder>(
+            config.at("primitive").get<std::string>()));
+    }
+    else
+    {
+        Real radius = scaling_config.jsonToReal(config.at("radius"), "Length");
+        Real half_height = scaling_config.jsonToReal(config.at("half_height"), "Length");
+        Transform transform = scaling_config.jsonToTransform(config.at("transform"));
+        return TransformGeometryCylinder(transform, radius, half_height);
+    }
+}
+#endif
+//=================================================================================================//
 SystemDomainConfig GeometryBuilder::parseSystemDomainConfig(
     const ScalingConfig &scaling_config, const json &config)
 {
@@ -351,6 +370,14 @@ Shape *GeometryBuilder::addShape(
         return shape;
     }
 #else
+    if (type == "cylinder")
+    {
+        TransformGeometryCylinder cylinder = fetch_or_parseCylinder(scaling_config, config_manager, config);
+        GeometricShapeCylinder *shape = config_manager.emplaceEntity<GeometricShapeCylinder>(name, cylinder, name);
+        shape->writeGeometricShapeCylinderToVtp(scaling_factor);
+        return shape;
+    }
+
     if (type == "triangle_mesh")
     {
         Vec3d translation = Vec3d::Zero();

--- a/sphinxsim/sph_simulation/common_builder/geometry_builder.h
+++ b/sphinxsim/sph_simulation/common_builder/geometry_builder.h
@@ -82,6 +82,12 @@ class GeometryBuilder
     static void addPrimitive(const ScalingConfig &scaling_config, EntityManager &config_manager, const json &config);
     static TransformGeometryBox fetch_or_parseBox(
         const ScalingConfig &scaling_config, EntityManager &config_manager, const json &config);
+
+#ifdef SPHINXSYS_3D
+    static TransformGeometryCylinder fetch_or_parseCylinder(
+        const ScalingConfig &scaling_config, EntityManager &config_manager, const json &config);
+#endif
+
     static Shape *addShape(const ScalingConfig &scaling_config, EntityManager &config_manager, const json &config);
     static GeometricShapeBox addOrientedBox(
         const ScalingConfig &scaling_config, EntityManager &config_manager, const json &config);

--- a/sphinxsim/sph_simulation/particle_generation/particle_generation.cpp
+++ b/sphinxsim/sph_simulation/particle_generation/particle_generation.cpp
@@ -194,7 +194,7 @@ void ParticleGeneration ::addAllBodies(
             }
         }
 
-        StdVec<GeometricShapeBox *> inserts;
+        StdVec<Shape *> inserts;
         if (bd.contains("box_shape_inserts"))
         {
             for (const auto &insert : bd.at("box_shape_inserts"))
@@ -202,6 +202,17 @@ void ParticleGeneration ::addAllBodies(
                 inserts.push_back(&config_manager.getEntity<GeometricShapeBox>(insert.get<std::string>()));
             }
         }
+
+#ifdef SPHINXSYS_3D
+        if (bd.contains("cylinder_shape_inserts"))
+        {
+            for (const auto &insert : bd.at("cylinder_shape_inserts"))
+            {
+                inserts.push_back(&config_manager.getEntity<GeometricShapeCylinder>(insert.get<std::string>()));
+            }
+        }
+#endif
+
         real_body.generateParticles<BaseParticles, Lattice>(blocks, inserts);
     }
 }

--- a/sphinxsim/sph_simulation/particle_generation/particle_generation.cpp
+++ b/sphinxsim/sph_simulation/particle_generation/particle_generation.cpp
@@ -194,12 +194,12 @@ void ParticleGeneration ::addAllBodies(
             }
         }
 
-        StdVec<OrientedBox *> inserts;
-        if (bd.contains("inserts"))
+        StdVec<GeometricShapeBox *> inserts;
+        if (bd.contains("box_shape_inserts"))
         {
-            for (const auto &insert : bd.at("inserts"))
+            for (const auto &insert : bd.at("box_shape_inserts"))
             {
-                inserts.push_back(&config_manager.getEntity<OrientedBox>(insert.get<std::string>()));
+                inserts.push_back(&config_manager.getEntity<GeometricShapeBox>(insert.get<std::string>()));
             }
         }
         real_body.generateParticles<BaseParticles, Lattice>(blocks, inserts);

--- a/sphinxsim/sphinxsys/src/for_2D_build/particle_generator/particle_generator_lattice_2d.cpp
+++ b/sphinxsim/sphinxsys/src/for_2D_build/particle_generator/particle_generator_lattice_2d.cpp
@@ -9,6 +9,36 @@
 namespace SPH
 {
 //=================================================================================================//
+ParticleGenerator<BaseParticles, Lattice>::
+    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, Shape &target_shape,
+                      StdVec<OrientedBox *> blocks, StdVec<Shape *> inserts)
+    : ParticleGenerator<BaseParticles>(sph_body, base_particles),
+      GeneratingMethod<Lattice>(sph_body), target_shape_(target_shape), blocks_(blocks)
+{
+    for (Shape *insert : inserts)
+    {
+        if (GeometricShapeBox *box_insert = DynamicCast<GeometricShapeBox>(this, insert))
+        {
+            box_shape_inserts_.push_back(box_insert);
+        }
+    }
+}
+//=================================================================================================//
+void ParticleGenerator<BaseParticles, Lattice>::addInserts(const Vecd &position, Real volume)
+{
+    for (GeometricShapeBox *insert : box_shape_inserts_)
+    {
+        Transform &transform = insert->getTransform();
+        Vecd inv_translation = position - transform.getTranslation();
+        auto &frame_geometry = insert->getFrameGeometry();
+        if (frame_geometry.checkContain(inv_translation))
+        {
+            addPositionAndVolumetricMeasure(
+                transform.shiftFrameStationToBase(inv_translation), volume);
+        }
+    }
+}
+//=================================================================================================//
 void ParticleGenerator<BaseParticles, Lattice>::prepareGeometricData()
 {
     Mesh mesh(domain_bounds_, lattice_spacing_, 0);

--- a/sphinxsim/sphinxsys/src/for_2D_build/particle_generator/particle_generator_lattice_2d.cpp
+++ b/sphinxsim/sphinxsys/src/for_2D_build/particle_generator/particle_generator_lattice_2d.cpp
@@ -17,9 +17,9 @@ ParticleGenerator<BaseParticles, Lattice>::
 {
     for (Shape *insert : inserts)
     {
-        if (GeometricShapeBox *box_insert = DynamicCast<GeometricShapeBox>(this, insert))
+        if (dynamic_cast<GeometricShapeBox *>(insert) != nullptr)
         {
-            box_shape_inserts_.push_back(box_insert);
+            box_shape_inserts_.push_back(dynamic_cast<GeometricShapeBox *>(insert));
         }
     }
 }

--- a/sphinxsim/sphinxsys/src/for_3D_build/geometries/geometric_element_and_shape_3d.cpp
+++ b/sphinxsim/sphinxsys/src/for_3D_build/geometries/geometric_element_and_shape_3d.cpp
@@ -84,6 +84,18 @@ GeometricShapeCylinder::GeometricShapeCylinder(const Transform &transform, Real 
                                                const std::string &name)
     : TransformShape<GeometricCylinder>(name, transform, radius, halflength) {}
 //=================================================================================================//
+GeometricShapeCylinder::GeometricShapeCylinder(const TransformGeometryCylinder &transformed_cylinder,
+                                               const std::string &name)
+    : GeometricShapeCylinder(Transform(transformed_cylinder.initialTransform()),
+                             transformed_cylinder.getRadius(),
+                             transformed_cylinder.getHalfLength(), name) {}    
+//=================================================================================================//
+void GeometricShapeCylinder::writeGeometricShapeCylinderToVtp(Real scale_factor)
+{
+    TriangleMeshShapeCylinder shape(Vec3d(1.0, 0.0, 0.0), radius_, halflength_, 20, Vecd::Zero(), Name());
+    shape.writTriangleMeshShapeToVtp(getTransform(), scale_factor);
+}
+//=================================================================================================//
 void GeometricShapeBox::writeGeometricShapeBoxToVtp(Real scale_factor)
 {
     TriangleMeshShapeBrick shape(HalfSize(), 1, Vecd::Zero(), Name());

--- a/sphinxsim/sphinxsys/src/for_3D_build/geometries/geometric_element_and_shape_3d.h
+++ b/sphinxsim/sphinxsys/src/for_3D_build/geometries/geometric_element_and_shape_3d.h
@@ -40,6 +40,8 @@ class GeometricCylinder
     explicit GeometricCylinder(Real radius, Real halflength);
     ~GeometricCylinder(){};
 
+    Real getRadius() const { return radius_; };
+    Real getHalfLength() const { return halflength_; };
     bool checkContain(const Vec3d &probe_point)
     {
         if (ABS(probe_point[0]) > halflength_)
@@ -62,6 +64,9 @@ class GeometricShapeCylinder : public TransformShape<GeometricCylinder>
   public:
     GeometricShapeCylinder(const Transform &transform, Real radius, Real halflength,
                            const std::string &name = "GeometricShapeCylinder");
+    GeometricShapeCylinder(const TransformGeometryCylinder &transformed_cylinder,
+                           const std::string &name = "GeometricShapeCylinder");                       
+    void writeGeometricShapeCylinderToVtp(Real scale_factor);                       
     virtual ~GeometricShapeCylinder(){};
 };
 } // namespace SPH

--- a/sphinxsim/sphinxsys/src/for_3D_build/particle_generator/particle_generator_lattice_3d.cpp
+++ b/sphinxsim/sphinxsys/src/for_3D_build/particle_generator/particle_generator_lattice_3d.cpp
@@ -5,9 +5,57 @@
 #include "base_particle_dynamics.h"
 #include "base_particles.h"
 #include "complex_geometry.h"
+#include "geometric_element_and_shape_3d.h"
 
 namespace SPH
 {
+//=================================================================================================//
+ParticleGenerator<BaseParticles, Lattice>::
+    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, Shape &target_shape,
+                      StdVec<OrientedBox *> blocks, StdVec<Shape *> inserts)
+    : ParticleGenerator<BaseParticles>(sph_body, base_particles),
+      GeneratingMethod<Lattice>(sph_body), target_shape_(target_shape), blocks_(blocks)
+{
+    for (Shape *insert : inserts)
+    {
+        if (dynamic_cast<GeometricShapeBox *>(insert) != nullptr)
+        {
+            box_shape_inserts_.push_back(dynamic_cast<GeometricShapeBox *>(insert));
+        }
+
+        if (dynamic_cast<GeometricShapeCylinder *>(insert) != nullptr)
+        {
+            cylinder_shape_inserts_.push_back(dynamic_cast<GeometricShapeCylinder *>(insert));
+        }
+    }
+}
+//=================================================================================================//
+void ParticleGenerator<BaseParticles, Lattice>::addInserts(const Vecd &position, Real volume)
+{
+    for (GeometricShapeBox *box_insert : box_shape_inserts_)
+    {
+        Transform &transform = box_insert->getTransform();
+        Vecd inv_translation = position - transform.getTranslation();
+        auto &frame_geometry = box_insert->getFrameGeometry();
+        if (frame_geometry.checkContain(inv_translation))
+        {
+            addPositionAndVolumetricMeasure(
+                transform.shiftFrameStationToBase(inv_translation), volume);
+        }
+    }
+
+    for (GeometricShapeCylinder *cylinder_insert : cylinder_shape_inserts_)
+    {
+        Transform &transform = cylinder_insert->getTransform();
+        Vecd inv_translation = position - transform.getTranslation();
+        auto &frame_geometry = cylinder_insert->getFrameGeometry();
+        if (frame_geometry.checkContain(inv_translation))
+        {
+            addPositionAndVolumetricMeasure(
+                transform.shiftFrameStationToBase(inv_translation), volume);
+        }
+    }
+}
 //=================================================================================================//
 void ParticleGenerator<BaseParticles, Lattice>::prepareGeometricData()
 {

--- a/sphinxsim/sphinxsys/src/shared/common/geometric_primitive.h
+++ b/sphinxsim/sphinxsys/src/shared/common/geometric_primitive.h
@@ -206,6 +206,10 @@ class BaseTransform
     {
         return xformBaseVecToFrame(target - translation_);
     };
+
+    VecType getTranslation() const { return translation_; };
+    RotationType getRotation() const { return RotationType(rotation_); };
+    RotationType getInvRotation() const { return RotationType(inv_rotation_); };
 };
 
 using Transform2d = BaseTransform<Rotation2d, Vec2d>;

--- a/sphinxsim/sphinxsys/src/shared/geometries/transform_geometry.h
+++ b/sphinxsim/sphinxsys/src/shared/geometries/transform_geometry.h
@@ -49,6 +49,7 @@ class TransformGeometry : public GeometryType
     Transform &getTransform() { return transform_; };
     Transform initialTransform() const { return initial_transform_; };
     void setTransform(const Transform &transform) { transform_ = transform; };
+    GeometryType &getFrameGeometry() { return *this; };
 
     bool checkContain(const Vecd &probe_point)
     {

--- a/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.cpp
+++ b/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.cpp
@@ -20,14 +20,8 @@ GeneratingMethod<Lattice>::GeneratingMethod(SPHBody &sph_body)
 }
 //=================================================================================================//
 ParticleGenerator<BaseParticles, Lattice>::
-    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, Shape &target_shape,
-                      StdVec<OrientedBox *> blocks, StdVec<GeometricShapeBox *> inserts)
-    : ParticleGenerator<BaseParticles>(sph_body, base_particles),
-      GeneratingMethod<Lattice>(sph_body), target_shape_(target_shape), blocks_(blocks), inserts_(inserts) {}
-//=================================================================================================//
-ParticleGenerator<BaseParticles, Lattice>::
     ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles,
-                      StdVec<OrientedBox *> blocks, StdVec<GeometricShapeBox *> inserts)
+                      StdVec<OrientedBox *> blocks, StdVec<Shape *> inserts)
     : ParticleGenerator(sph_body, base_particles, sph_body.getInitialShape(), blocks, inserts) {}
 //=================================================================================================//
 void ParticleGenerator<BaseParticles, Lattice>::
@@ -50,21 +44,6 @@ bool ParticleGenerator<BaseParticles, Lattice>::checkBlocks(const Vecd &position
         is_blocked = !is_blocked && block->checkLowerBound(position);
     }
     return is_blocked;
-}
-//=================================================================================================//
-void ParticleGenerator<BaseParticles, Lattice>::addInserts(const Vecd &position, Real volume)
-{
-    for (GeometricShapeBox *insert : inserts_)
-    {
-        Transform &transform = insert->getTransform();
-        Vecd inv_translation = position - transform.getTranslation();
-        auto &frame_geometry = insert->getFrameGeometry();
-        if (frame_geometry.checkContain(inv_translation))
-        {
-            addPositionAndVolumetricMeasure(
-                transform.shiftFrameStationToBase(inv_translation), volume);
-        }
-    }
 }
 //=================================================================================================//
 ParticleGenerator<SurfaceParticles, Lattice>::

--- a/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.cpp
+++ b/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.cpp
@@ -21,13 +21,13 @@ GeneratingMethod<Lattice>::GeneratingMethod(SPHBody &sph_body)
 //=================================================================================================//
 ParticleGenerator<BaseParticles, Lattice>::
     ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, Shape &target_shape,
-                      StdVec<OrientedBox *> blocks, StdVec<OrientedBox *> inserts)
+                      StdVec<OrientedBox *> blocks, StdVec<GeometricShapeBox *> inserts)
     : ParticleGenerator<BaseParticles>(sph_body, base_particles),
       GeneratingMethod<Lattice>(sph_body), target_shape_(target_shape), blocks_(blocks), inserts_(inserts) {}
 //=================================================================================================//
 ParticleGenerator<BaseParticles, Lattice>::
     ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles,
-                      StdVec<OrientedBox *> blocks, StdVec<OrientedBox *> inserts)
+                      StdVec<OrientedBox *> blocks, StdVec<GeometricShapeBox *> inserts)
     : ParticleGenerator(sph_body, base_particles, sph_body.getInitialShape(), blocks, inserts) {}
 //=================================================================================================//
 void ParticleGenerator<BaseParticles, Lattice>::
@@ -54,7 +54,7 @@ bool ParticleGenerator<BaseParticles, Lattice>::checkBlocks(const Vecd &position
 //=================================================================================================//
 void ParticleGenerator<BaseParticles, Lattice>::addInserts(const Vecd &position, Real volume)
 {
-    for (OrientedBox *insert : inserts_)
+    for (GeometricShapeBox *insert : inserts_)
     {
         Transform &transform = insert->getTransform();
         Vecd inv_translation = position - transform.getTranslation();

--- a/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.cpp
+++ b/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.cpp
@@ -56,9 +56,13 @@ void ParticleGenerator<BaseParticles, Lattice>::addInserts(const Vecd &position,
 {
     for (OrientedBox *insert : inserts_)
     {
-        if (insert->checkContain(position))
+        Transform &transform = insert->getTransform();
+        Vecd inv_translation = position - transform.getTranslation();
+        auto &frame_geometry = insert->getFrameGeometry();
+        if (frame_geometry.checkContain(inv_translation))
         {
-            addPositionAndVolumetricMeasure(position, volume);
+            addPositionAndVolumetricMeasure(
+                transform.shiftFrameStationToBase(inv_translation), volume);
         }
     }
 }

--- a/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.h
+++ b/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.h
@@ -38,6 +38,8 @@ namespace SPH
 class Shape;
 class AdaptiveByShape;
 class SurfaceParticles;
+class GeometricShapeBox;
+class GeometricShapeCylinder;
 class OrientedBox;
 
 template <> // Base class for generating particles from lattice positions
@@ -61,17 +63,17 @@ class ParticleGenerator<BaseParticles, Lattice>
   public:
     ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, Shape &target_shape,
                       StdVec<OrientedBox *> blocks = StdVec<OrientedBox *>{},
-                      StdVec<OrientedBox *> inserts = StdVec<OrientedBox *>{});
+                      StdVec<GeometricShapeBox *> inserts = StdVec<GeometricShapeBox *>{});
     ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles,
                       StdVec<OrientedBox *> blocks = StdVec<OrientedBox *>{},
-                      StdVec<OrientedBox *> inserts = StdVec<OrientedBox *>{});
+                      StdVec<GeometricShapeBox *> inserts = StdVec<GeometricShapeBox *>{});
     virtual ~ParticleGenerator() {};
     virtual void prepareGeometricData() override;
 
   protected:
     Shape &target_shape_;
     StdVec<OrientedBox *> blocks_;
-    StdVec<OrientedBox *> inserts_;
+    StdVec<GeometricShapeBox *> inserts_;
     virtual void addPositionAndVolumetricMeasure(const Vecd &position, Real volume) override;
     bool checkBlocks(const Vecd &position);
     void addInserts(const Vecd &position, Real volume);

--- a/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.h
+++ b/sphinxsim/sphinxsys/src/shared/particle_generator/particle_generator_lattice.h
@@ -63,17 +63,18 @@ class ParticleGenerator<BaseParticles, Lattice>
   public:
     ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, Shape &target_shape,
                       StdVec<OrientedBox *> blocks = StdVec<OrientedBox *>{},
-                      StdVec<GeometricShapeBox *> inserts = StdVec<GeometricShapeBox *>{});
+                      StdVec<Shape *> inserts = StdVec<Shape *>{});
     ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles,
                       StdVec<OrientedBox *> blocks = StdVec<OrientedBox *>{},
-                      StdVec<GeometricShapeBox *> inserts = StdVec<GeometricShapeBox *>{});
+                      StdVec<Shape *> inserts = StdVec<Shape *>{});
     virtual ~ParticleGenerator() {};
     virtual void prepareGeometricData() override;
 
   protected:
     Shape &target_shape_;
     StdVec<OrientedBox *> blocks_;
-    StdVec<GeometricShapeBox *> inserts_;
+    StdVec<GeometricShapeBox *> box_shape_inserts_;
+    StdVec<GeometricShapeCylinder *> cylinder_shape_inserts_;
     virtual void addPositionAndVolumetricMeasure(const Vecd &position, Real volume) override;
     bool checkBlocks(const Vecd &position);
     void addInserts(const Vecd &position, Real volume);

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -470,6 +470,25 @@ class TestSimulationConfig:
 
         assert len(cfg.geometries.system_domain.lower_bound) == 3
         assert all(shape.type.value != "multipolygon" for shape in cfg.geometries.shapes)
+        assert any(shape.type.value == "cylinder" for shape in cfg.geometries.shapes)
+
+    def test_2d_config_rejects_cylinder_shape(self):
+        data = _make_minimal_fluid_config().model_dump(mode="json", exclude_none=True)
+        data["geometries"]["shapes"].append(
+            {
+                "name": "EmitterCylinder",
+                "type": "cylinder",
+                "radius": 0.05,
+                "half_height": 0.025,
+                "transform": {
+                    "translation": [0.5, 1.5],
+                    "rotation_angle": 0.0,
+                },
+            }
+        )
+
+        with pytest.raises(ValidationError, match="cylinder shapes are 3D-only"):
+            SimulationConfig.model_validate(data)
 
     def test_3d_repose_angle_fixture_uses_plastic_continuum(self):
         data_path = Path("tests/test_simulation/test_3d_simulation/data/repose_angle.json")
@@ -686,6 +705,39 @@ class TestSimulationConfig:
                     },
                 }
             )
+
+    def test_particle_generation_box_shape_inserts_reject_non_box_shape(self):
+        data_path = Path("tests/test_simulation/test_3d_simulation/data/dambreak.json")
+        data = json.loads(data_path.read_text())
+        data["particle_generation"]["settings"]["bodies"][0]["box_shape_inserts"] = ["WallBoundary"]
+
+        with pytest.raises(ValidationError, match="box-compatible shapes"):
+            SimulationConfig.model_validate(data)
+
+    def test_particle_generation_cylinder_shape_inserts_accept_existing_cylinder_shape(self):
+        data_path = Path("tests/test_simulation/test_3d_simulation/data/dambreak.json")
+        data = json.loads(data_path.read_text())
+
+        cfg = SimulationConfig.model_validate(data)
+
+        assert cfg.particle_generation.settings is not None
+        assert cfg.particle_generation.settings.bodies[0].cylinder_shape_inserts == ["EmitterCylinder"]
+
+    def test_particle_generation_cylinder_shape_inserts_reject_unknown_shape(self):
+        data_path = Path("tests/test_simulation/test_3d_simulation/data/dambreak.json")
+        data = json.loads(data_path.read_text())
+        data["particle_generation"]["settings"]["bodies"][0]["cylinder_shape_inserts"] = ["MissingShape"]
+
+        with pytest.raises(ValidationError, match="cylinder_shape_inserts entries must reference existing"):
+            SimulationConfig.model_validate(data)
+
+    def test_particle_generation_cylinder_shape_inserts_reject_non_cylinder_shape(self):
+        data_path = Path("tests/test_simulation/test_3d_simulation/data/dambreak.json")
+        data = json.loads(data_path.read_text())
+        data["particle_generation"]["settings"]["bodies"][0]["cylinder_shape_inserts"] = ["WallInnerBox"]
+
+        with pytest.raises(ValidationError, match="must reference cylinder shapes"):
+            SimulationConfig.model_validate(data)
 
     def test_particle_generation_body_unknown_field_warns_and_is_preserved(self):
         with pytest.warns(UserWarning, match="contains unknown keys that are preserved"):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -656,13 +656,13 @@ class TestSimulationConfig:
                 }
             )
 
-    def test_particle_generation_inserts_accept_existing_oriented_box(self):
+    def test_particle_generation_box_shape_inserts_accept_existing_shape(self):
         cfg = _make_minimal_fluid_config(
             particle_generation={
                 "build_and_run": False,
                 "settings": {
                     "bodies": [
-                        {"name": "WaterBody", "inserts": ["Inlet"]},
+                        {"name": "WaterBody", "box_shape_inserts": ["WallBoundary"]},
                         {"name": "WallBoundary", "solid_body": {}},
                     ],
                     "relaxation_parameters": {"total_iterations": 1000},
@@ -670,16 +670,16 @@ class TestSimulationConfig:
             }
         )
         assert cfg.particle_generation.settings is not None
-        assert cfg.particle_generation.settings.bodies[0].inserts == ["Inlet"]
+        assert cfg.particle_generation.settings.bodies[0].box_shape_inserts == ["WallBoundary"]
 
-    def test_particle_generation_inserts_reject_unknown_oriented_box(self):
-        with pytest.raises(ValidationError, match="inserts entries must reference existing"):
+    def test_particle_generation_box_shape_inserts_reject_unknown_shape(self):
+        with pytest.raises(ValidationError, match="box_shape_inserts entries must reference existing"):
             _make_minimal_fluid_config(
                 particle_generation={
                     "build_and_run": False,
                     "settings": {
                         "bodies": [
-                            {"name": "WaterBody", "inserts": ["MissingBox"]},
+                            {"name": "WaterBody", "box_shape_inserts": ["MissingShape"]},
                             {"name": "WallBoundary", "solid_body": {}},
                         ],
                         "relaxation_parameters": {"total_iterations": 1000},

--- a/tests/test_simulation/test_2d_simulation/data/multi_phase_mixing.json
+++ b/tests/test_simulation/test_2d_simulation/data/multi_phase_mixing.json
@@ -40,6 +40,11 @@
         "upper_bound": [2.0, 0.5]
       },
       {
+        "name": "EmitterInsert",
+        "type": "box",
+        "primitive": "EmitterBox"
+      },
+      {
         "name": "WallBoundary",
         "type": "multipolygon",
         "polygons": [
@@ -80,7 +85,7 @@
         {
           "name": "MultiPhaseBody",
           "blocks": ["FillLevel"],
-          "inserts": ["Emitter"]
+          "box_shape_inserts": ["EmitterInsert"]
         },
         {
           "name": "WallBoundary",

--- a/tests/test_simulation/test_2d_simulation/data/multi_phase_mixing.json
+++ b/tests/test_simulation/test_2d_simulation/data/multi_phase_mixing.json
@@ -28,7 +28,7 @@
         "half_size": [0.05, 0.025],
         "transform": {
           "translation": [0.5, 1.5],
-          "rotation_angle": 0.0
+          "rotation_angle": 0.7854
         }
       }
     ],

--- a/tests/test_simulation/test_3d_simulation/data/dambreak.json
+++ b/tests/test_simulation/test_3d_simulation/data/dambreak.json
@@ -15,6 +15,17 @@
         "upper_bound": [2.0, 1.0, 0.5]
       },
       {
+        "name": "EmitterCylinder",
+        "type": "cylinder",
+        "radius": 0.05,
+        "half_height": 0.025,
+        "transform": {
+          "translation": [0.5, 1.5, 0.25],
+          "rotation_angle": 0.7854,
+          "rotation_axis": [0.0, 0.0, 1.0]
+        }
+      },
+      {
         "name": "WallInnerBox",
         "type": "bounding_box",
         "lower_bound": [0.0, 0.0, 0.0],

--- a/tests/test_simulation/test_3d_simulation/data/dambreak.json
+++ b/tests/test_simulation/test_3d_simulation/data/dambreak.json
@@ -17,8 +17,8 @@
       {
         "name": "EmitterCylinder",
         "type": "cylinder",
-        "radius": 0.05,
-        "half_height": 0.025,
+        "radius": 0.1,
+        "half_height": 0.1,
         "transform": {
           "translation": [0.5, 1.5, 0.25],
           "rotation_angle": 0.7854,
@@ -43,6 +43,18 @@
         "sub_shapes": ["WallOuterBox", "WallInnerBox"],
         "operations": ["union", "subtraction"]
       }
+    ],
+    "oriented_boxes": [
+      {
+        "name": "Emitter",
+        "type": "region",
+        "half_size": [0.1, 0.125, 0.125],
+        "transform": {
+          "translation": [0.5, 1.5, 0.25],
+          "rotation_angle": 0.7854,
+          "rotation_axis": [0.0, 0.0, 1.0]
+        }
+      }
     ]
   },
 
@@ -51,7 +63,8 @@
     "settings": {
       "bodies": [
         {
-          "name": "WaterBody"
+          "name": "WaterBody",
+          "cylinder_shape_inserts": ["EmitterCylinder"]
         },
         {
           "name": "WallBoundary",
@@ -70,7 +83,8 @@
       "material": {
         "type": "weakly_compressible_fluid",
         "density": 1.0
-      }
+      },
+      "particle_reserve_factor": 1.0
     }
   ],
 
@@ -79,6 +93,19 @@
       "name": "WallBoundary",
       "material": {
         "type": "rigid_body"
+      }
+    }
+  ],
+
+  "fluid_boundary_conditions": [
+    {
+      "body_name": "WaterBody",
+      "oriented_box": "Emitter",
+      "type": "emitter",
+      "inflow_speed": 2.0,
+      "on_schedule": {
+        "switch_on_time": 1.0,
+        "duration": 5.0
       }
     }
   ],
@@ -103,7 +130,7 @@
 
   "solver_parameters": {
     "end_time": 20.0,
-    "output_interval": 0.01,
+    "output_interval": 0.1,
     "screen_interval": 100,
     "fluid_dynamics": {
       "acoustic_cfl": 0.6,


### PR DESCRIPTION
This pull request adds support for cylinder-shaped geometry inserts in the particle generation pipeline, alongside significant refactoring to generalize shape handling and improve validation. The changes affect both the configuration schema and the C++ geometry/particle generation logic, ensuring that both box and cylinder shapes can be referenced and used for particle insertion. Additionally, the code now enforces shape compatibility checks and restricts cylinder shapes to 3D configurations.

**Configuration schema and validation changes:**

* Added `CYLINDER` to `BodyShapeType`, and introduced `radius` and `half_height` fields to `ShapeConfig` for cylinder shapes. Validation logic now ensures these fields are present for cylinders and restricts cylinders to 3D configurations. [[1]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289R55) [[2]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289R218-R220) [[3]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289R258-R262) [[4]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289R1208-R1209)
* Refactored `ParticleGenerationBodyConfig` to use separate `box_shape_inserts` and `cylinder_shape_inserts` lists, with validation enforcing that each insert references a compatible shape type. [[1]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289L371-R381) [[2]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289R987) [[3]](diffhunk://#diff-9ab61b64616428e39701751d6a6e3249d9c7f9806be42c97c5155dfae5e5e289L1056-R1091)

**C++ geometry and particle generation logic:**

* Implemented support for parsing and creating `GeometricShapeCylinder` objects, including new methods in `GeometryBuilder` and serialization to VTP. [[1]](diffhunk://#diff-a919ad3f389fa0aea84a720124a1777080bf1fa2c2cc182bc04f25a1c5702331R158-R176) [[2]](diffhunk://#diff-a919ad3f389fa0aea84a720124a1777080bf1fa2c2cc182bc04f25a1c5702331R373-R380) [[3]](diffhunk://#diff-fac39f1a2d732712f71a0e759309e2b7ea0cd09ee170f57ca8ccd0ed18095017R85-R90) [[4]](diffhunk://#diff-f86957d22beff5b0f2e1b65893641b9849de12b92065987b8b39000577169bc7R87-R98) [[5]](diffhunk://#diff-dfcb98490fd47ee99da85ca038a01d399155df27555674334294b6f12300d6e2R43-R44) [[6]](diffhunk://#diff-dfcb98490fd47ee99da85ca038a01d399155df27555674334294b6f12300d6e2R67-R69)
* Refactored particle generator constructors and insert handling to accept a generic list of `Shape*`, allowing both box and cylinder inserts. Updated insert logic to properly handle each shape type in both 2D and 3D builds. [[1]](diffhunk://#diff-90fb6d373ace4ebd1d16f15d82bc6357c2cbf749e75d7ba464615a518f6e8397L197-R215) [[2]](diffhunk://#diff-ac98d344b1aab1bf74b5482b58a30bd7317e45e53e08ee1b2d8531eb3624a341R12-R41) [[3]](diffhunk://#diff-d2002abaca1936f6e720eb6b7010a3f1ef62580fb5888a12025ba2872fdd8135R8-R59) [[4]](diffhunk://#diff-af4e17401d0cf82dbddd3ffb5e3272702ddde7fc960491b0cd06e51271dc4d81L22-R24) [[5]](diffhunk://#diff-af4e17401d0cf82dbddd3ffb5e3272702ddde7fc960491b0cd06e51271dc4d81L55-L65) [[6]](diffhunk://#diff-7be23bf5d69fa74c044f194b63c0770e9e8ca6074712c129d4bbcf231d7db229R41-R42)

**Generalization and utility improvements:**

* Added utility methods to `BaseTransform` and `TransformGeometry` for easier access to translation and geometry. [[1]](diffhunk://#diff-8f473208a97f9602ec310da1a850f1890e96f1cea1fdc5f7e96c9fe391ddc709R209-R212) [[2]](diffhunk://#diff-f4cc85dabba8788fc3d1792b194ab40152e31e960d192ced83e86cab40401c8cR52)