### PR TITLE
Xiangyu/constrain inserts

### DIFF
--- a/sphinxsim/sph_simulation/particle_generation/particle_generation.cpp
+++ b/sphinxsim/sph_simulation/particle_generation/particle_generation.cpp
@@ -53,6 +53,7 @@ void ParticleGeneration::buildParticleGeneration(SPHSimulation &sim, const json 
         [&]()
         {
             randomize_particle_position.exec();
+            relaxation_pipeline_.run_hooks(RelaxationHookPoint::Initialization);
             dummy_cell_linked_list.exec();
 
             UnsignedInt ite_p = 0;
@@ -427,6 +428,10 @@ ParticleDynamicsGroup &ParticleGeneration::addRelaxationConstraints(
             relaxation_constraints.add(
                 &main_methods.template addStateDynamics<OrientedBoxConstraint, CovariantVectorAxis>(
                     body_part, "KernelGradientIntegral", 0));
+
+            auto &initial_fix = main_methods.template addStateDynamics<FixConstraintCK>(body_part);
+            relaxation_pipeline_.insert_hook(RelaxationHookPoint::Initialization, [&]()
+                                             { initial_fix.exec(); });
         }
         else
         {

--- a/sphinxsim/sph_simulation/particle_generation/particle_generation.cpp
+++ b/sphinxsim/sph_simulation/particle_generation/particle_generation.cpp
@@ -410,8 +410,7 @@ ParticleDynamicsGroup &ParticleGeneration::addRelaxationConstraints(
         {
             auto &body_part = real_body.addBodyPart<BodyRegionByParticle>(*insert);
             relaxation_constraints.add(
-                &main_methods.template addStateDynamics<ConstantConstraintCK, Vecd>(
-                    body_part, "KernelGradientIntegral", Vecd::Zero()));
+                &main_methods.template addStateDynamics<FixConstraintCK>(body_part));
         }
     }
 
@@ -432,8 +431,7 @@ ParticleDynamicsGroup &ParticleGeneration::addRelaxationConstraints(
         else
         {
             relaxation_constraints.add(
-                &main_methods.template addStateDynamics<ConstantConstraintCK, Vecd>(
-                    body_part, "KernelGradientIntegral", Vecd::Zero()));
+                &main_methods.template addStateDynamics<FixConstraintCK>(body_part));
         }
     }
     return relaxation_constraints;

--- a/sphinxsim/sph_simulation/particle_generation/particle_generation.cpp
+++ b/sphinxsim/sph_simulation/particle_generation/particle_generation.cpp
@@ -194,7 +194,8 @@ void ParticleGeneration ::addAllBodies(
             }
         }
 
-        StdVec<Shape *> inserts;
+        StdVec<Shape *> &inserts =
+            *config_manager.emplaceEntity<StdVec<Shape *>>(body_name + "inserts", StdVec<Shape *>{});
         if (bd.contains("box_shape_inserts"))
         {
             for (const auto &insert : bd.at("box_shape_inserts"))
@@ -399,6 +400,21 @@ ParticleDynamicsGroup &ParticleGeneration::addRelaxationConstraints(
     MainMethods &main_methods, const json &config)
 {
     ParticleDynamicsGroup &relaxation_constraints = main_methods.addParticleDynamicsGroup();
+
+    for (const auto &body_config : bodies_config_.all_bodies_)
+    {
+        const std::string body_name = body_config.name_;
+        RealBody &real_body = relaxation_system.getBodyByName<RealBody>(body_name);
+        StdVec<Shape *> &inserts = config_manager.getEntity<StdVec<Shape *>>(body_name + "inserts");
+        for (const auto &insert : inserts)
+        {
+            auto &body_part = real_body.addBodyPart<BodyRegionByParticle>(*insert);
+            relaxation_constraints.add(
+                &main_methods.template addStateDynamics<ConstantConstraintCK, Vecd>(
+                    body_part, "KernelGradientIntegral", Vecd::Zero()));
+        }
+    }
+
     for (const auto &rc : config)
     {
         const std::string body_name = rc.at("body_name").get<std::string>();

--- a/sphinxsim/sph_simulation/sph_simulation.cpp
+++ b/sphinxsim/sph_simulation/sph_simulation.cpp
@@ -76,10 +76,11 @@ void SPHSimulation::generateParticles()
     json config = loadConfig().at("particle_generation");
     if (config.at("build_and_run").get<bool>())
     {
-        particle_generation_ptr_ = std::make_unique<ParticleGeneration>();
-        particle_generation_ptr_->buildParticleGeneration(*this, config.at("settings"));
-        particle_generation_ptr_->runRelaxation();
+        ParticleGeneration particle_generation;
+        particle_generation.buildParticleGeneration(*this, config.at("settings"));
+        particle_generation.runRelaxation();
     }
+    particles_generated_ = true;
 }
 //=================================================================================================//
 void SPHSimulation::buildGeometries()
@@ -94,10 +95,10 @@ void SPHSimulation::buildGeometries()
 //=================================================================================================//
 void SPHSimulation::buildSimulation()
 {
-    if (!particle_generation_ptr_)
+    if (!particles_generated_)
     {
-        std::cerr << "SPHSimulation::buildSimulation: ParticleGeneration not found. "
-                     "Call createParticlesGeneration() before buildSimulation().\n";
+        std::cerr << "SPHSimulation::buildSimulation: particles not generated. "
+                     "Call generateParticles() before buildSimulation().\n";
         exit(1);
     }
 

--- a/sphinxsim/sph_simulation/sph_simulation.h
+++ b/sphinxsim/sph_simulation/sph_simulation.h
@@ -96,11 +96,11 @@ class SPHSimulation
     StagePipeline<InitializationHookPoint> initialization_pipeline_;
     StagePipeline<SimulationHookPoint> simulation_pipeline_;
     std::unique_ptr<RecordingBuilder> recording_builder_ptr_;
-    std::unique_ptr<ParticleGeneration> particle_generation_ptr_;
     std::unique_ptr<SPHSystem> sph_system_ptr_;
     std::unique_ptr<SPHSolver> sph_solver_ptr_;
     UniquePtrsKeeper<Contact<>> structure_contacts_keeper_;
     bool geometry_built_{false};
+    bool particles_generated_{false};
     bool executable_simulation_state_ready_{false};
     json loadConfig();
 };

--- a/sphinxsim/sphinxsys/src/shared/particle_dynamics/reduce_functors.h
+++ b/sphinxsim/sphinxsys/src/shared/particle_dynamics/reduce_functors.h
@@ -123,7 +123,7 @@ struct IndexedMin : ReturnFunction<Indexed<Real>>
             return x;
         if (std::isnan(y.first))
             return y;
-        return x.first > y.first ? x : y;
+        return x.first < y.first ? x : y;
     };
 };
 

--- a/tests/test_simulation/test_2d_simulation/data/multi_phase_mixing.json
+++ b/tests/test_simulation/test_2d_simulation/data/multi_phase_mixing.json
@@ -163,7 +163,7 @@
   "extra_state_recording": [
     {
       "name": "MultiPhaseBody",
-      "variables": [{ "real_type": ["Density"] }]
+      "variables": [{ "real_type": ["Density", "Compression"] }]
     }
   ],
 

--- a/tests/test_simulation/test_2d_simulation/data/multi_phase_mixing.json
+++ b/tests/test_simulation/test_2d_simulation/data/multi_phase_mixing.json
@@ -85,11 +85,19 @@
         {
           "name": "MultiPhaseBody",
           "blockers": ["FillLevel"],
-          "box_shape_inserts": ["EmitterInsert"]
+          "box_shape_inserts": ["EmitterInsert"],
+          "relaxation": { "dependent_bodies": ["WallBoundary"] }
         },
         {
           "name": "WallBoundary",
           "solid_body": {}
+        }
+      ],
+      "relaxation_constraints": [
+        {
+          "body_name": "MultiPhaseBody",
+          "oriented_box": "FillLevel",
+          "type": "normal"
         }
       ],
       "relaxation_parameters": {


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the particle generation and relaxation constraint handling within the SPH simulation framework, as well as updates to test configurations. The main changes include enhancing the relaxation pipeline with initialization hooks, correcting a reduction functor, simplifying particle generation state management, and updating test data to reflect new constraint and variable tracking capabilities.

**Particle generation and relaxation pipeline improvements:**
- Added support for running initialization hooks in the relaxation pipeline by invoking `relaxation_pipeline_.run_hooks(RelaxationHookPoint::Initialization)` during particle position randomization.
- Inserted an initialization hook to execute `FixConstraintCK` dynamics for oriented box constraints, ensuring proper constraint setup during relaxation.
- Added logic to automatically add `FixConstraintCK` constraints for all body inserts defined in the configuration, improving the flexibility and correctness of relaxation constraints. [[1]](diffhunk://#diff-90fb6d373ace4ebd1d16f15d82bc6357c2cbf749e75d7ba464615a518f6e8397R404-R417) [[2]](diffhunk://#diff-90fb6d373ace4ebd1d16f15d82bc6357c2cbf749e75d7ba464615a518f6e8397L197-R199)

**Simulation state management:**
- Replaced the `particle_generation_ptr_` pointer with a simpler `particles_generated_` boolean flag, streamlining the particle generation process and error handling in `SPHSimulation`. [[1]](diffhunk://#diff-2b259acf3469cab5aa66541505042cb74eff0f524194db08f34e4e271e495448L79-R83) [[2]](diffhunk://#diff-2b259acf3469cab5aa66541505042cb74eff0f524194db08f34e4e271e495448L97-R101) [[3]](diffhunk://#diff-086587a6a92095287c68f00bdd112706207fea2fb7f16336c96a10b47586b70aL99-R103)

**Bug fixes:**
- Fixed the `IndexedMin` reduction functor to correctly return the minimum value, addressing a logic error in comparison.

**Test and configuration updates:**
- Updated the `multi_phase_mixing.json` test configuration to include a `relaxation` section with dependent bodies, a new `relaxation_constraints` entry, and additional variables (`Compression`) for state recording. [[1]](diffhunk://#diff-3dcef9d6e411f15814cee31070720d8f5dfe1bc1bc15707b95477a89c51870f9L88-R102) [[2]](diffhunk://#diff-3dcef9d6e411f15814cee31070720d8f5dfe1bc1bc15707b95477a89c51870f9L158-R166)