### PR TITLE
Move build_and_run to generateParticles argument

### DIFF
--- a/sphinxsim/bindings/sphinxsys_python.cpp
+++ b/sphinxsim/bindings/sphinxsys_python.cpp
@@ -43,7 +43,9 @@ PYBIND11_MODULE(MODULE_NAME, m)
         .def("getShapeBounds", &SPHSimulation::getShapeBounds,
              "Return dict of shape_name -> (lower_bound, upper_bound) after buildGeometries()")
         .def("generateParticles", &SPHSimulation::generateParticles,
-             "Generate particles for all bodies from configuration")
+             py::arg("build_and_run") = true,
+             "Generate particles for all bodies from configuration when build_and_run is true; "
+             "otherwise use existing reload files")
         .def("buildSimulation", &SPHSimulation::buildSimulation,
              "Build simulation (relations, dynamics, etc.) from JSON configuration")
         .def("initializeSimulation", &SPHSimulation::initializeSimulation,

--- a/sphinxsim/config/schemas.py
+++ b/sphinxsim/config/schemas.py
@@ -426,14 +426,8 @@ class ParticleGenerationSettingsConfig(BaseModel):
 
 
 class ParticleGenerationConfig(BaseModel):
-    build_and_run: bool
     settings: Optional[ParticleGenerationSettingsConfig] = None
 
-    @model_validator(mode="after")
-    def _validate_settings(self) -> "ParticleGenerationConfig":
-        if self.build_and_run and self.settings is None:
-            raise ValueError("particle_generation.settings is required when build_and_run is true")
-        return self
 
 
 class VariableConfig(BaseModel):

--- a/sphinxsim/llm/mock_llm.py
+++ b/sphinxsim/llm/mock_llm.py
@@ -51,7 +51,6 @@ _FLUID_TEMPLATE: Dict[str, Any] = {
         ],
     },
     "particle_generation": {
-        "build_and_run": True,
         "settings": {
             "bodies": [
                 {"name": "WaterBody"},
@@ -118,7 +117,6 @@ _SOLID_TEMPLATE: Dict[str, Any] = {
         ],
     },
     "particle_generation": {
-        "build_and_run": True,
         "settings": {
             "bodies": [
                 {"name": "ProcessingPiece"},
@@ -183,7 +181,6 @@ _FSI_TEMPLATE: Dict[str, Any] = {
         ],
     },
     "particle_generation": {
-        "build_and_run": True,
         "settings": {
             "bodies": [
                 {"name": "WaterBody"},

--- a/sphinxsim/sph_simulation/sph_simulation.cpp
+++ b/sphinxsim/sph_simulation/sph_simulation.cpp
@@ -65,7 +65,7 @@ EntityManager &SPHSimulation::getConfigManager()
     return config_manager_;
 }
 //=================================================================================================//
-void SPHSimulation::generateParticles()
+void SPHSimulation::generateParticles(bool build_and_run)
 {
     if (!geometry_built_)
     {
@@ -75,7 +75,7 @@ void SPHSimulation::generateParticles()
     }
 
     json config = loadConfig().at("particle_generation");
-    if (config.at("build_and_run").get<bool>())
+    if (build_and_run)
     {
         ParticleGeneration particle_generation;
         particle_generation.buildParticleGeneration(*this, config.at("settings"));

--- a/sphinxsim/sph_simulation/sph_simulation.h
+++ b/sphinxsim/sph_simulation/sph_simulation.h
@@ -57,7 +57,7 @@ class SPHSimulation
     void resetOutputRoot(const fs::path &output_root, bool keep_existing = false);
     void buildGeometries();
     std::map<std::string, std::pair<std::vector<double>, std::vector<double>>> getShapeBounds();
-    void generateParticles();
+    void generateParticles(bool build_and_run = true);
     void buildSimulation();
     void initializeSimulation();
     void run();

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -398,8 +398,8 @@ class ConfigVisualizer:
                     self._shape_bounds_cache = None
 
             # Optionally generate particles so preview can overlay the latest
-            # body particle clouds if particle_generation is enabled.
-            if with_particles and self.config.particle_generation.build_and_run:
+            # body particle clouds when requested.
+            if with_particles:
                 sim = sph.SPHSimulation(str(runtime_config_path))
                 sim.resetOutputRoot(str(vtp_output_dir), True)
                 sim.buildGeometries()

--- a/tests/examples/full_updated_simulation_config.json
+++ b/tests/examples/full_updated_simulation_config.json
@@ -48,7 +48,6 @@
     ]
   },
   "particle_generation": {
-    "build_and_run": false,
     "settings": {
       "bodies": [
         {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,7 +61,6 @@ def _valid_data() -> dict:
             ],
         },
         "particle_generation": {
-            "build_and_run": True,
             "settings": {
                 "bodies": [
                     {"name": "WaterBody"},

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -40,7 +40,6 @@ def _make_minimal_fluid_config(**overrides) -> SimulationConfig:
             ],
         },
         "particle_generation": {
-            "build_and_run": False,
             "settings": {
                 "bodies": [
                     {"name": "WaterBody"},
@@ -115,7 +114,6 @@ def _make_minimal_continuum_config(**overrides) -> SimulationConfig:
             ],
         },
         "particle_generation": {
-            "build_and_run": False,
             "settings": {
                 "bodies": [
                     {"name": "ContinuumBody"},
@@ -443,7 +441,6 @@ class TestSimulationConfig:
         ]
 
         particle_generation = {
-            "build_and_run": False,
             "settings": {
                 "bodies": [
                     {"name": "TetraBody"},
@@ -647,7 +644,6 @@ class TestSimulationConfig:
     def test_particle_generation_blockers_accept_existing_oriented_box(self):
         cfg = _make_minimal_fluid_config(
             particle_generation={
-                "build_and_run": False,
                 "settings": {
                     "bodies": [
                         {"name": "WaterBody", "blockers": ["Inlet"]},
@@ -664,7 +660,6 @@ class TestSimulationConfig:
         with pytest.raises(ValidationError, match="blockers entries must reference existing"):
             _make_minimal_fluid_config(
                 particle_generation={
-                    "build_and_run": False,
                     "settings": {
                         "bodies": [
                             {"name": "WaterBody", "blockers": ["MissingBox"]},
@@ -678,7 +673,6 @@ class TestSimulationConfig:
     def test_particle_generation_box_shape_inserts_accept_existing_shape(self):
         cfg = _make_minimal_fluid_config(
             particle_generation={
-                "build_and_run": False,
                 "settings": {
                     "bodies": [
                         {"name": "WaterBody", "box_shape_inserts": ["WallBoundary"]},
@@ -695,7 +689,6 @@ class TestSimulationConfig:
         with pytest.raises(ValidationError, match="box_shape_inserts entries must reference existing"):
             _make_minimal_fluid_config(
                 particle_generation={
-                    "build_and_run": False,
                     "settings": {
                         "bodies": [
                             {"name": "WaterBody", "box_shape_inserts": ["MissingShape"]},
@@ -743,7 +736,6 @@ class TestSimulationConfig:
         with pytest.warns(UserWarning, match="contains unknown keys that are preserved"):
             cfg = _make_minimal_fluid_config(
                 particle_generation={
-                    "build_and_run": False,
                     "settings": {
                         "bodies": [
                             {"name": "WaterBody", "unknown_key": ["Inlet"]},

--- a/tests/test_simulation/test_2d_simulation/data/column_collapse.json
+++ b/tests/test_simulation/test_2d_simulation/data/column_collapse.json
@@ -31,7 +31,6 @@
   },
 
   "particle_generation": {
-    "build_and_run": true,
     "settings": {
       "bodies": [
         {

--- a/tests/test_simulation/test_2d_simulation/data/dambreak.json
+++ b/tests/test_simulation/test_2d_simulation/data/dambreak.json
@@ -45,7 +45,6 @@
   },
 
   "particle_generation": {
-    "build_and_run": true,
     "settings": {
       "bodies": [
         {

--- a/tests/test_simulation/test_2d_simulation/data/filling_tank.json
+++ b/tests/test_simulation/test_2d_simulation/data/filling_tank.json
@@ -47,7 +47,6 @@
     ]
   },
   "particle_generation": {
-    "build_and_run": true,
     "settings": {
       "bodies": [
         {

--- a/tests/test_simulation/test_2d_simulation/data/fish.json
+++ b/tests/test_simulation/test_2d_simulation/data/fish.json
@@ -64,7 +64,6 @@
     ]
   },
   "particle_generation": {
-    "build_and_run": true,
     "settings": {
       "bodies": [
         {

--- a/tests/test_simulation/test_2d_simulation/data/heat_transfer.json
+++ b/tests/test_simulation/test_2d_simulation/data/heat_transfer.json
@@ -84,7 +84,6 @@
   },
 
   "particle_generation": {
-    "build_and_run": true,
     "settings": {
       "bodies": [
         {

--- a/tests/test_simulation/test_2d_simulation/data/milling.json
+++ b/tests/test_simulation/test_2d_simulation/data/milling.json
@@ -41,7 +41,6 @@
   },
 
   "particle_generation": {
-    "build_and_run": true,
     "settings": {
       "bodies": [
         {

--- a/tests/test_simulation/test_2d_simulation/data/multi_phase_mixing.json
+++ b/tests/test_simulation/test_2d_simulation/data/multi_phase_mixing.json
@@ -79,7 +79,6 @@
     ]
   },
   "particle_generation": {
-    "build_and_run": true,
     "settings": {
       "bodies": [
         {

--- a/tests/test_simulation/test_2d_simulation/data/t_junction.json
+++ b/tests/test_simulation/test_2d_simulation/data/t_junction.json
@@ -106,7 +106,6 @@
   },
 
   "particle_generation": {
-    "build_and_run": true,
     "settings": {
       "bodies": [
         {

--- a/tests/test_simulation/test_2d_simulation/simulation.cpp
+++ b/tests/test_simulation/test_2d_simulation/simulation.cpp
@@ -118,6 +118,19 @@ TEST(simulations, has_json)
     ASSERT_FALSE(json_files.empty()) << "No JSON examples found in ./input";
 }
 
+TEST(simulations, particle_generation_can_be_skipped)
+{
+    const auto json_files = collectJsonConfigs("./input");
+    ASSERT_FALSE(json_files.empty()) << "No JSON examples found in ./input";
+
+    const fs::path config = json_files.front();
+    SPH::SPHSimulation sim(config);
+    sim.resetOutputRoot(fs::path("./skip_particle_generation"), true);
+    sim.buildGeometries();
+
+    EXPECT_NO_THROW(sim.generateParticles(false));
+}
+
 TEST_P(Json, run)
 {
     const fs::path config = GetParam();
@@ -126,7 +139,7 @@ TEST_P(Json, run)
     SPH::SPHSimulation sim(config);
     sim.resetOutputRoot(fs::path("./") / config.stem(), true);
     sim.buildGeometries();
-    sim.generateParticles();
+    sim.generateParticles(true);
     sim.buildSimulation();
     sim.initializeSimulation();
     sim.run();

--- a/tests/test_simulation/test_3d_simulation/data/dambreak.json
+++ b/tests/test_simulation/test_3d_simulation/data/dambreak.json
@@ -59,7 +59,6 @@
   },
 
   "particle_generation": {
-    "build_and_run": true,
     "settings": {
       "bodies": [
         {

--- a/tests/test_simulation/test_3d_simulation/data/repose_angle.json
+++ b/tests/test_simulation/test_3d_simulation/data/repose_angle.json
@@ -36,7 +36,6 @@
   },
 
   "particle_generation": {
-    "build_and_run": true,
     "settings": {
       "bodies": [
         {

--- a/tests/test_simulation/test_3d_simulation/data/t_pipe.json
+++ b/tests/test_simulation/test_3d_simulation/data/t_pipe.json
@@ -61,7 +61,6 @@
   },
 
   "particle_generation": {
-    "build_and_run": true,
     "settings": {
       "bodies": [
         {

--- a/tests/test_simulation/test_3d_simulation/simulation.cpp
+++ b/tests/test_simulation/test_3d_simulation/simulation.cpp
@@ -128,7 +128,7 @@ TEST_P(Json, run)
     SPHSimulation sim(config);
     sim.resetOutputRoot(fs::path("./") / config.stem(), true);
     sim.buildGeometries();
-    sim.generateParticles();
+    sim.generateParticles(true);
     sim.buildSimulation();
     sim.initializeSimulation();
     sim.run();

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -60,7 +60,6 @@ def _minimal_fluid_config() -> dict:
             ],
         },
         "particle_generation": {
-            "build_and_run": True,
             "settings": {
                 "bodies": [
                     {"name": "WaterBody"},


### PR DESCRIPTION
Moves `build_and_run` from the particle generation JSON configuration to the `generateParticles()` function argument.

Changes:
- removed `build_and_run` from particle generation configs
- added `build_and_run` argument to `generateParticles()`
- updated Python bindings and call sites
- updated tests and example configs
- added coverage for `generateParticles(false)`

Tests:
- CTest: 14/14 passed
- pytest: 288 passed, 6 skipped

Closes #115 