### PR TITLE
Add SYCL CPU build and test job to CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,10 +329,9 @@ jobs:
         run: |
           pytest examples/ -v
 
-  build-linux-sycl:
-    name: build (linux, sycl)
+  build-and-test-linux-sycl:
+    name: build-and-test (linux, sycl)
     runs-on: ubuntu-22.04
-    timeout-minutes: 150
     permissions:
       contents: read
     env:
@@ -412,12 +411,19 @@ jobs:
             -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -D Python3_EXECUTABLE="$PYTHON_EXE"
 
-      - name: Build (compile only, tests are not executed)
+      - name: Build (SYCL CPU)
         run: |
           source /opt/intel/oneapi/setvars.sh --include-intel-llvm
           cmake --build --preset sycl-cpu-binding \
             --parallel $(nproc) \
             --verbose
+
+      - name: Run C++ simulation class tests (SYCL CPU)
+        run: |
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          ctest --test-dir ${{ github.workspace }}/build-integrated \
+            --output-on-failure \
+            -L "simulation_class"
 
   wheel-smoke:
     name: wheel-smoke (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,8 +336,9 @@ jobs:
       contents: read
     env:
       VCPKG_DEFAULT_TRIPLET: x64-linux
+      SPHINXSIM_LLM_PROVIDER: mock
       PYTHONDONTWRITEBYTECODE: "1"
-
+      CTEST_PARALLEL_LEVEL: "1"
     steps:
       - name: Checkout repository (with submodules)
         uses: actions/checkout@v4
@@ -418,12 +419,110 @@ jobs:
             --parallel $(nproc) \
             --verbose
 
-      - name: Run C++ simulation class tests (SYCL CPU)
+      - name: Test with the first try
+        id: first-try
         run: |
           source /opt/intel/oneapi/setvars.sh --include-intel-llvm
           ctest --test-dir ${{ github.workspace }}/build-integrated \
-            --output-on-failure \
+            --output-on-failure --timeout 1000 \
             -L "simulation_class"
+        continue-on-error: true
+
+      - name: Test with the second try for failed cases
+        id: second-try
+        if: ${{ steps.first-try.outcome == 'failure' }}
+        run: |
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          ctest --test-dir ${{ github.workspace }}/build-integrated \
+            --rerun-failed --output-on-failure --timeout 1000
+        continue-on-error: true
+
+      - name: Test with the third try for failed cases
+        id: third-try
+        if: ${{ steps.second-try.outcome == 'failure' }}
+        run: |
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          ctest --test-dir ${{ github.workspace }}/build-integrated \
+            --rerun-failed --output-on-failure --timeout 1000
+        continue-on-error: true
+
+      - name: Test with the fourth try for failed cases
+        id: fourth-try
+        if: ${{ steps.third-try.outcome == 'failure' }}
+        run: |
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          ctest --test-dir ${{ github.workspace }}/build-integrated \
+            --rerun-failed --output-on-failure --timeout 1000
+        continue-on-error: true
+
+      - name: Test with the fifth try for failed cases
+        id: fifth-try
+        if: ${{ steps.fourth-try.outcome == 'failure' }}
+        run: |
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          ctest --test-dir ${{ github.workspace }}/build-integrated \
+            --rerun-failed --output-on-failure --timeout 1000
+        continue-on-error: true
+
+      - name: Test with the sixth try for failed cases
+        id: sixth-try
+        if: ${{ steps.fifth-try.outcome == 'failure' }}
+        run: |
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          ctest --test-dir ${{ github.workspace }}/build-integrated \
+            --rerun-failed --output-on-failure --timeout 1000
+        continue-on-error: true
+
+      - name: Test with the seventh try for failed cases
+        id: seventh-try
+        if: ${{ steps.sixth-try.outcome == 'failure' }}
+        run: |
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          ctest --test-dir ${{ github.workspace }}/build-integrated \
+            --rerun-failed --output-on-failure --timeout 1000
+        continue-on-error: true
+
+      - name: Test with the eighth try for failed cases
+        id: eighth-try
+        if: ${{ steps.seventh-try.outcome == 'failure' }}
+        run: |
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          ctest --test-dir ${{ github.workspace }}/build-integrated \
+            --rerun-failed --output-on-failure --timeout 1000
+        continue-on-error: true
+
+      - name: Test with the ninth try for failed cases
+        id: ninth-try
+        if: ${{ steps.eighth-try.outcome == 'failure' }}
+        run: |
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          ctest --test-dir ${{ github.workspace }}/build-integrated \
+            --rerun-failed --output-on-failure --timeout 1000
+        continue-on-error: true
+
+      - name: Test with the last try for failed cases
+        if: ${{ steps.ninth-try.outcome == 'failure' }}
+        run: |
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          ctest --test-dir ${{ github.workspace }}/build-integrated \
+            --rerun-failed --output-on-failure --timeout 1000
+
+      - name: Install Python package (editable with dev dependencies)
+        run: |
+          PYTHON_EXE=$(which python3)
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          export CMAKE_ARGS="-D CMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -D CMAKE_C_COMPILER=icx -D CMAKE_CXX_COMPILER=icpx -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache -D SPHINXSYS_USE_SYCL=ON"
+          "$PYTHON_EXE" -m pip install -e ".[dev]"
+
+      - name: Run unit tests (tests/)
+        run: |
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          pytest tests/ -v
+
+      - name: Run example tests (examples/)
+        run: |
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          pytest examples/ -v
 
   wheel-smoke:
     name: wheel-smoke (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,6 @@ jobs:
       VCPKG_DEFAULT_TRIPLET: x64-linux
       SPHINXSIM_LLM_PROVIDER: mock
       PYTHONDONTWRITEBYTECODE: "1"
-      CTEST_PARALLEL_LEVEL: "1"
     steps:
       - name: Checkout repository (with submodules)
         uses: actions/checkout@v4
@@ -419,93 +418,12 @@ jobs:
             --parallel $(nproc) \
             --verbose
 
-      - name: Test with the first try
-        id: first-try
+      - name: Run C++ simulation class tests (SYCL CPU)
         run: |
           source /opt/intel/oneapi/setvars.sh --include-intel-llvm
           ctest --test-dir ${{ github.workspace }}/build-integrated \
             --output-on-failure --timeout 1000 \
             -L "simulation_class"
-        continue-on-error: true
-
-      - name: Test with the second try for failed cases
-        id: second-try
-        if: ${{ steps.first-try.outcome == 'failure' }}
-        run: |
-          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
-          ctest --test-dir ${{ github.workspace }}/build-integrated \
-            --rerun-failed --output-on-failure --timeout 1000
-        continue-on-error: true
-
-      - name: Test with the third try for failed cases
-        id: third-try
-        if: ${{ steps.second-try.outcome == 'failure' }}
-        run: |
-          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
-          ctest --test-dir ${{ github.workspace }}/build-integrated \
-            --rerun-failed --output-on-failure --timeout 1000
-        continue-on-error: true
-
-      - name: Test with the fourth try for failed cases
-        id: fourth-try
-        if: ${{ steps.third-try.outcome == 'failure' }}
-        run: |
-          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
-          ctest --test-dir ${{ github.workspace }}/build-integrated \
-            --rerun-failed --output-on-failure --timeout 1000
-        continue-on-error: true
-
-      - name: Test with the fifth try for failed cases
-        id: fifth-try
-        if: ${{ steps.fourth-try.outcome == 'failure' }}
-        run: |
-          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
-          ctest --test-dir ${{ github.workspace }}/build-integrated \
-            --rerun-failed --output-on-failure --timeout 1000
-        continue-on-error: true
-
-      - name: Test with the sixth try for failed cases
-        id: sixth-try
-        if: ${{ steps.fifth-try.outcome == 'failure' }}
-        run: |
-          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
-          ctest --test-dir ${{ github.workspace }}/build-integrated \
-            --rerun-failed --output-on-failure --timeout 1000
-        continue-on-error: true
-
-      - name: Test with the seventh try for failed cases
-        id: seventh-try
-        if: ${{ steps.sixth-try.outcome == 'failure' }}
-        run: |
-          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
-          ctest --test-dir ${{ github.workspace }}/build-integrated \
-            --rerun-failed --output-on-failure --timeout 1000
-        continue-on-error: true
-
-      - name: Test with the eighth try for failed cases
-        id: eighth-try
-        if: ${{ steps.seventh-try.outcome == 'failure' }}
-        run: |
-          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
-          ctest --test-dir ${{ github.workspace }}/build-integrated \
-            --rerun-failed --output-on-failure --timeout 1000
-        continue-on-error: true
-
-      - name: Test with the ninth try for failed cases
-        id: ninth-try
-        if: ${{ steps.eighth-try.outcome == 'failure' }}
-        run: |
-          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
-          ctest --test-dir ${{ github.workspace }}/build-integrated \
-            --rerun-failed --output-on-failure --timeout 1000
-        continue-on-error: true
-
-      - name: Test with the last try for failed cases
-        if: ${{ steps.ninth-try.outcome == 'failure' }}
-        run: |
-          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
-          ctest --test-dir ${{ github.workspace }}/build-integrated \
-            --rerun-failed --output-on-failure --timeout 1000
 
       - name: Install Python package (editable with dev dependencies)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master]
     paths:
+      - ".github/workflows/**" #check self before pushing
       - "examples/**"
       - "tests/**"
       - "sphinxsim/**"
@@ -14,6 +15,7 @@ on:
   pull_request:
     branches: [main, master]
     paths:
+      - ".github/workflows/**" #check self before pushing
       - "examples/**"
       - "tests/**"
       - "sphinxsim/**"
@@ -326,6 +328,96 @@ jobs:
       - name: Run example tests (examples/)
         run: |
           pytest examples/ -v
+
+  build-linux-sycl:
+    name: build (linux, sycl)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 150
+    permissions:
+      contents: read
+    env:
+      VCPKG_DEFAULT_TRIPLET: x64-linux
+      PYTHONDONTWRITEBYTECODE: "1"
+
+    steps:
+      - name: Checkout repository (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up CMake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.x"
+
+      - name: Install system dependencies and Intel oneAPI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            apt-utils \
+            build-essential \
+            curl zip unzip tar \
+            pkg-config \
+            git \
+            ninja-build \
+            python3-dev \
+            autoconf automake autoconf-archive \
+            libxmu-dev libxi-dev libgl-dev libxt-dev
+          wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+            | gpg --dearmor \
+            | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
+            | sudo tee /etc/apt/sources.list.d/oneAPI.list
+          sudo apt-get update
+          sudo apt-get install -y intel-cpp-essentials
+
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}-${{ runner.os }}
+
+      - name: Set up vcpkg
+        uses: friendlyanon/setup-vcpkg@v1
+        with:
+          committish: ${{ env.VCPKG_VERSION }}
+          cache-version: ${{ env.VCPKG_VERSION }}-sycl
+
+      - name: Install C++ dependencies via vcpkg
+        run: |
+          ${{ github.workspace }}/vcpkg/vcpkg install --clean-after-build \
+            openblas[dynamic-arch] --allow-unsupported
+          ${{ github.workspace }}/vcpkg/vcpkg install --clean-after-build \
+            eigen3 \
+            tbb \
+            boost-program-options \
+            boost-geometry \
+            simbody \
+            spdlog \
+            gtest \
+            pybind11 \
+            nlohmann-json
+
+      - name: Configure CMake (SYCL CPU backend)
+        run: |
+          PYTHON_EXE=$(which python3)
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          cmake --preset sycl-cpu-binding \
+            -D CMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+            -D CMAKE_C_COMPILER_LAUNCHER=ccache \
+            -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -D Python3_EXECUTABLE="$PYTHON_EXE"
+
+      - name: Build (compile only, tests are not executed)
+        run: |
+          source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+          cmake --build --preset sycl-cpu-binding \
+            --parallel $(nproc) \
+            --verbose
 
   wheel-smoke:
     name: wheel-smoke (${{ matrix.os }})


### PR DESCRIPTION
1.Trigger CI on workflow changes


Added .github/workflows/** to the paths filter of the push and pull_request triggers. A commit touching only CI config previously matched no path and never ran, so CI edits could only be validated after merging or via a manual workflow_dispatch. CI is now self-checking, and this PR is covered by the rule it adds.

2.New job: build-and-test (linux, sycl)

Builds with the Intel oneAPI SYCL compiler on ubuntu-22.04 and runs the C++ tests. CPU backend only, no GPU runner. And there is ctest only, no pytest. The sycl-cpu-binding preset sets neither SPHINXSIM_COPY_BINDINGS_AFTER_BUILD nor SPHINXSIM_BINDINGS_OUTPUT_DIR (CMakeLists.txt:8, copy rules at 104-135), so the built extension never reaches sphinxsim/bindings/native/ — the directory sphinxsim/bindings/loader.py imports from, and which is generated at build time rather than checked in. pytest would fail at import. ctest is unaffected: it runs the binaries in build-integrated directly.

So enabling pytest here will change the preset itself.

3.Validation
By manual workflow_dispatch on this branch (run #295, 05748ba): all 7 jobs green, the SYCL job at 68m01s.
https://github.com/Xiangyu-Hu/SPHinXsim/actions/runs/31745278230