### PR TITLE
only inelastic materials kept in continuum dynamics

### DIFF
--- a/sphinxsim/config/schemas.py
+++ b/sphinxsim/config/schemas.py
@@ -853,7 +853,7 @@ class FluidDynamicsSolverConfig(BaseModel):
 class ContinuumDynamicsSolverConfig(BaseModel):
     acoustic_cfl: float = Field(default=0.4, gt=0)
     advection_cfl: float = Field(default=0.2, gt=0)
-    # These controls apply to GeneralContinuum/J2Plasticity. PlasticContinuum
+    # These controls apply to J2Plasticity. PlasticContinuum
     # removes them during cross-validation because it does not build the
     # corresponding correction, repulsion, shear, or hourglass dynamics.
     linear_correction_matrix_coeff: Optional[float] = 0.5

--- a/sphinxsim/sph_simulation/common_builder/material_builder.cpp
+++ b/sphinxsim/sph_simulation/common_builder/material_builder.cpp
@@ -115,18 +115,6 @@ void MaterialBuilder::addMatterMaterial(
         return;
     }
 
-    if (type == "general_continuum")
-    {
-        Real density = scaling_config.jsonToReal(config.at("density"), "Density");
-        Real sound_speed = scaling_config.jsonToReal(config.at("sound_speed"), "Speed");
-        Real youngs_modulus = scaling_config.jsonToReal(config.at("youngs_modulus"), "Stress");
-        Real poisson_ratio = scaling_config.jsonToReal(config.at("poisson_ratio"), "Dimensionless");
-        auto &material = sph_body.defineMatterMaterial<GeneralContinuum>(
-            density, sound_speed, youngs_modulus, poisson_ratio);
-        config_manager.addEntity(sph_body.Name() + "GeneralContinuum", &material);
-        return;
-    }
-
     if (type == "plastic_continuum")
     {
         Real density = scaling_config.jsonToReal(config.at("density"), "Density");

--- a/sphinxsim/sph_simulation/dynamics_builder/continuum_dynamics/continuum_dynamics_builder.cpp
+++ b/sphinxsim/sph_simulation/dynamics_builder/continuum_dynamics/continuum_dynamics_builder.cpp
@@ -132,20 +132,11 @@ void ContinuumDynamicsBuilder::buildShearForceIntegrationIfPresent(
             auto &continuum_solver_parameters = config_manager.getEntity<
                 ContinuumSolverParameters>("ContinuumSolverParameters");
 
-            if (config_manager.hasEntity<GeneralContinuum>(body_name + "GeneralContinuum"))
-            {
-                continuum_shear_force
-                    .add(&main_methods.template addInteractionDynamicsOneLevel<
-                          continuum_dynamics::ShearIntegration, GeneralContinuum>(
-                        inner_relation, continuum_solver_parameters.hourglass_factor_,
-                        continuum_solver_parameters.shear_stress_damping_));
-            }
-
             if (config_manager.hasEntity<J2Plasticity>(body_name + "J2Plasticity"))
             {
                 continuum_shear_force
                     .add(&main_methods.template addInteractionDynamicsOneLevel<
-                          continuum_dynamics::ShearIntegration, J2Plasticity>(
+                          continuum_dynamics::InelasticShearIntegration, J2Plasticity>(
                         inner_relation, continuum_solver_parameters.hourglass_factor_,
                         continuum_solver_parameters.shear_stress_damping_));
             }
@@ -184,7 +175,7 @@ void ContinuumDynamicsBuilder::buildContactRepulsionIfPresent(
             {
                 std::string tgt_body_name = cb_tgt->name_;
                 if (body_name != tgt_body_name &&
-                    !config_manager.hasEntity<GeneralContinuum>(tgt_body_name + "PlasticContinuum"))
+                    !config_manager.hasEntity<PlasticContinuum>(tgt_body_name + "PlasticContinuum"))
                 {
                     std::string relation_name = body_name + tgt_body_name;
                     auto &contact_relation =

--- a/sphinxsim/sph_simulation/dynamics_builder/continuum_dynamics/continuum_interaction_builder.hpp
+++ b/sphinxsim/sph_simulation/dynamics_builder/continuum_dynamics/continuum_interaction_builder.hpp
@@ -17,14 +17,6 @@ BaseDynamics<void> &ContinuumDynamicsBuilder::addAcousticStep1stHalfForOneBody(
     auto &config_manager = sim.getConfigManager();
     std::string body_name = inner_relation.getSPHBody().Name();
 
-    if (config_manager.hasEntity<GeneralContinuum>(body_name + "GeneralContinuum"))
-    {
-        using RiemannSolverType = RiemannSolver<GeneralContinuum, GeneralContinuum, NoLimiter>;
-        return main_methods.template addInteractionDynamics<
-            fluid_dynamics::AcousticStep1stHalf, OneLevel,
-            RiemannSolverType, NoKernelCorrectionCK>(inner_relation);
-    }
-
     if (config_manager.hasEntity<J2Plasticity>(body_name + "J2Plasticity"))
     {
         using RiemannSolverType = RiemannSolver<J2Plasticity, J2Plasticity, NoLimiter>;
@@ -66,14 +58,6 @@ BaseDynamics<void> &ContinuumDynamicsBuilder::addAcousticStep2ndHalfForOneBody(
 {
     auto &config_manager = sim.getConfigManager();
     std::string body_name = inner_relation.getSPHBody().Name();
-
-    if (config_manager.hasEntity<GeneralContinuum>(body_name + "GeneralContinuum"))
-    {
-        using RiemannSolverType = RiemannSolver<GeneralContinuum, GeneralContinuum, NoLimiter>;
-        return main_methods.template addInteractionDynamics<
-            fluid_dynamics::AcousticStep2ndHalf, OneLevel,
-            RiemannSolverType, NoKernelCorrectionCK>(inner_relation);
-    }
 
     if (config_manager.hasEntity<J2Plasticity>(body_name + "J2Plasticity"))
     {

--- a/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/continuum_dynamics/shear_integration.h
+++ b/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/continuum_dynamics/shear_integration.h
@@ -38,7 +38,6 @@ namespace SPH
 {
 namespace continuum_dynamics
 {
-
 template <typename...>
 class ShearIntegration;
 
@@ -55,6 +54,61 @@ class ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>
     template <class DynamicsIdentifier>
     explicit ShearIntegration(DynamicsIdentifier &identifier, Real xi = 2.0, Real shear_stress_damping = 0.0);
     virtual ~ShearIntegration() {};
+
+    class InitializeKernel
+    {
+      public:
+        template <class ExecutionPolicy, class EncloserType>
+        InitializeKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
+        void initialize(size_t index_i, Real dt = 0.0);
+
+      protected:
+        ConstituteKernel constitute_;
+        SmoothingLengthRatioType h_ratio_;
+        Real h_ref_, shear_stress_damping_, xi_;
+        Matd *vel_gradient_, *strain_tensor_, *shear_stress_;
+        Real *scale_penalty_force_;
+    };
+
+    class InteractKernel : public BaseInteraction::InteractKernel
+    {
+      public:
+        template <class ExecutionPolicy, class EncloserType>
+        InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
+        void interact(size_t index_i, Real dt = 0.0);
+
+      protected:
+        Real G_;
+        Vecd *shear_force_, *vel_, *hourglass_force_;
+        Matd *vel_gradient_, *shear_stress_;
+        Real *Vol_, *scale_penalty_force_;
+    };
+
+  protected:
+    MaterialType &material_;
+    Adaptation &adaptation_;
+    Real h_ref_, shear_stress_damping_, xi_;
+    DiscreteVariable<Vecd> *dv_shear_force_, *dv_vel_, *dv_hourglass_force_;
+    DiscreteVariable<Matd> *dv_vel_gradient_, *dv_strain_tensor_, *dv_shear_stress_;
+    DiscreteVariable<Real> *dv_Vol_, *dv_scale_penalty_force_;
+};
+
+template <typename...>
+class InelasticShearIntegration;
+
+template <class MaterialType, typename... Parameters>
+class InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>
+    : public Interaction<Inner<Parameters...>>, public ForcePriorCK
+{
+    using BaseInteraction = Interaction<Inner<Parameters...>>;
+    using Adaptation = typename Inner<Parameters...>::SourceType::Adaptation;
+    using SmoothingLengthRatioType = typename Adaptation::SmoothingLengthRatioType;
+    using ConstituteKernel = typename MaterialType::ConstituteKernel;
+
+  public:
+    template <class DynamicsIdentifier>
+    explicit InelasticShearIntegration(DynamicsIdentifier &identifier, Real xi = 2.0, Real shear_stress_damping = 0.0);
+    virtual ~InelasticShearIntegration() {};
 
     class InitializeKernel
     {

--- a/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/continuum_dynamics/shear_integration.hpp
+++ b/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/continuum_dynamics/shear_integration.hpp
@@ -20,7 +20,7 @@ ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
       h_ref_(adaptation_.ReferenceSmoothingLength()), shear_stress_damping_(shear_stress_damping),
       xi_(xi), dv_shear_force_(this->getCurrentForce()),
       dv_vel_(this->particles_->template getVariableByName<Vecd>("Velocity")),
-      dv_hourglass_div_(this->particles_->template registerStateVariable<Vecd>("HourglassStressDivergence")),
+      dv_hourglass_force_(this->particles_->template registerStateVariable<Vecd>("HourglassForce")),
       dv_vel_gradient_(this->particles_->template getVariableByName<Matd>("VelocityGradient")),
       dv_strain_tensor_(this->particles_->template registerStateVariable<Matd>("StrainTensor")),
       dv_shear_stress_(this->particles_->template registerStateVariable<Matd>("ShearStress")),
@@ -29,7 +29,7 @@ ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
 {
     this->particles_->template addEvolvingVariable<Matd>(dv_strain_tensor_);
     this->particles_->template addEvolvingVariable<Matd>(dv_shear_stress_);
-    this->particles_->template addEvolvingVariable<Vecd>(dv_hourglass_div_);
+    this->particles_->template addEvolvingVariable<Vecd>(dv_hourglass_force_);
 }
 //====================================================================================//
 template <class MaterialType, typename... Parameters>
@@ -68,11 +68,10 @@ template <class ExecutionPolicy, class EncloserType>
 ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::InteractKernel::
     InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
     : BaseInteraction::InteractKernel(ex_policy, encloser),
-      constitute_(ex_policy, encloser.material_),
       G_(encloser.material_.ShearModulus()),
       shear_force_(encloser.dv_shear_force_->DelegatedData(ex_policy)),
       vel_(encloser.dv_vel_->DelegatedData(ex_policy)),
-      hourglass_div_(encloser.dv_hourglass_div_->DelegatedData(ex_policy)),
+      hourglass_force_(encloser.dv_hourglass_force_->DelegatedData(ex_policy)),
       vel_gradient_(encloser.dv_vel_gradient_->DelegatedData(ex_policy)),
       shear_stress_(encloser.dv_shear_stress_->DelegatedData(ex_policy)),
       Vol_(encloser.dv_Vol_->DelegatedData(ex_policy)),
@@ -98,6 +97,98 @@ void ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
         sum_hourglass += penalty_scale * G_ * v_ij_correction.dot(e_ij) * vec_r_ij *
                          dW_ijV_j / vec_r_ij.squaredNorm();
     }
+    hourglass_force_[index_i] += sum_hourglass * Vol_[index_i] * dt;
+    shear_force_[index_i] = sum_shear * Vol_[index_i] + hourglass_force_[index_i];
+}
+//====================================================================================//
+template <class MaterialType, typename... Parameters>
+template <class DynamicsIdentifier>
+InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
+    InelasticShearIntegration(DynamicsIdentifier &identifier, Real xi, Real shear_stress_damping)
+    : BaseInteraction(identifier), ForcePriorCK(this->particles_, "ShearForce"),
+      material_(DynamicCast<MaterialType>(this, this->sph_body_->getMatterMaterial())),
+      adaptation_(DynamicCast<Adaptation>(this, this->sph_body_->getSPHAdaptation())),
+      h_ref_(adaptation_.ReferenceSmoothingLength()), shear_stress_damping_(shear_stress_damping),
+      xi_(xi), dv_shear_force_(this->getCurrentForce()),
+      dv_vel_(this->particles_->template getVariableByName<Vecd>("Velocity")),
+      dv_hourglass_div_(this->particles_->template registerStateVariable<Vecd>("HourglassStressDivergence")),
+      dv_vel_gradient_(this->particles_->template getVariableByName<Matd>("VelocityGradient")),
+      dv_strain_tensor_(this->particles_->template registerStateVariable<Matd>("StrainTensor")),
+      dv_shear_stress_(this->particles_->template registerStateVariable<Matd>("ShearStress")),
+      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure")),
+      dv_scale_penalty_force_(this->particles_->template registerStateVariable<Real>("ScalePenaltyForce"))
+{
+    this->particles_->template addEvolvingVariable<Matd>(dv_strain_tensor_);
+    this->particles_->template addEvolvingVariable<Matd>(dv_shear_stress_);
+    this->particles_->template addEvolvingVariable<Vecd>(dv_hourglass_div_);
+}
+//====================================================================================//
+template <class MaterialType, typename... Parameters>
+template <class ExecutionPolicy, class EncloserType>
+InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::InitializeKernel::
+    InitializeKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
+    : constitute_(ex_policy, encloser.material_),
+      h_ratio_(ex_policy, encloser.adaptation_), h_ref_(encloser.h_ref_),
+      shear_stress_damping_(encloser.shear_stress_damping_), xi_(encloser.xi_),
+      vel_gradient_(encloser.dv_vel_gradient_->DelegatedData(ex_policy)),
+      strain_tensor_(encloser.dv_strain_tensor_->DelegatedData(ex_policy)),
+      shear_stress_(encloser.dv_shear_stress_->DelegatedData(ex_policy)),
+      scale_penalty_force_(encloser.dv_scale_penalty_force_->DelegatedData(ex_policy)) {}
+//====================================================================================//
+template <class MaterialType, typename... Parameters>
+void InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
+    InitializeKernel::initialize(size_t index_i, Real dt)
+{
+    Matd strain_rate = 0.5 * (vel_gradient_[index_i] + vel_gradient_[index_i].transpose());
+    strain_tensor_[index_i] += strain_rate * dt;
+
+    Matd shear_stress_rate =
+        constitute_.ShearStressRate(index_i, vel_gradient_[index_i], shear_stress_[index_i]);
+    Matd shear_stress_try = shear_stress_[index_i] + shear_stress_rate * dt;
+    constitute_.updateIntactFactor(index_i);
+    scale_penalty_force_[index_i] = xi_ * constitute_.ScalePenaltyForce(index_i, shear_stress_try);
+    shear_stress_[index_i] =
+        constitute_.updateShearStress(index_i, shear_stress_try) +
+        shear_stress_damping_ * constitute_.NumericalDampingStress(
+                                    strain_tensor_[index_i],
+                                    strain_rate, h_ref_ / h_ratio_(index_i), index_i);
+}
+//====================================================================================//
+template <class MaterialType, typename... Parameters>
+template <class ExecutionPolicy, class EncloserType>
+InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::InteractKernel::
+    InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
+    : BaseInteraction::InteractKernel(ex_policy, encloser),
+      constitute_(ex_policy, encloser.material_),
+      G_(encloser.material_.ShearModulus()),
+      shear_force_(encloser.dv_shear_force_->DelegatedData(ex_policy)),
+      vel_(encloser.dv_vel_->DelegatedData(ex_policy)),
+      hourglass_div_(encloser.dv_hourglass_div_->DelegatedData(ex_policy)),
+      vel_gradient_(encloser.dv_vel_gradient_->DelegatedData(ex_policy)),
+      shear_stress_(encloser.dv_shear_stress_->DelegatedData(ex_policy)),
+      Vol_(encloser.dv_Vol_->DelegatedData(ex_policy)),
+      scale_penalty_force_(encloser.dv_scale_penalty_force_->DelegatedData(ex_policy)) {}
+//====================================================================================//
+template <class MaterialType, typename... Parameters>
+void InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
+    InteractKernel::interact(size_t index_i, Real dt)
+{
+    Vecd sum_shear = Vecd::Zero();
+    Vecd sum_hourglass = Vecd::Zero();
+    for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
+    {
+        UnsignedInt index_j = this->neighbor_index_[n];
+        Real dW_ijV_j = this->dW_ij(index_i, index_j) * Vol_[index_j];
+        Vecd e_ij = this->e_ij(index_i, index_j);
+        Vecd vec_r_ij = this->vec_r_ij(index_i, index_j);
+
+        sum_shear += (shear_stress_[index_i] + shear_stress_[index_j]) * dW_ijV_j * e_ij;
+        Vecd v_ij_correction = vel_[index_i] - vel_[index_j] -
+                               0.5 * (vel_gradient_[index_i] + vel_gradient_[index_j]) * vec_r_ij;
+        Real penalty_scale = 0.5 * (scale_penalty_force_[index_i] + scale_penalty_force_[index_j]);
+        sum_hourglass += penalty_scale * G_ * v_ij_correction.dot(e_ij) * vec_r_ij *
+                         dW_ijV_j / vec_r_ij.squaredNorm();
+    }
     hourglass_div_[index_i] = constitute_.updateHourglassForce(
         index_i, hourglass_div_[index_i], sum_hourglass * dt);
     shear_force_[index_i] = sum_shear * Vol_[index_i];
@@ -105,7 +196,7 @@ void ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
 //====================================================================================//
 template <class MaterialType, typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>
-ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::UpdateKernel::
+InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::UpdateKernel::
     UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
     : BaseInteraction::InteractKernel(ex_policy, encloser),
       ForcePriorCK::UpdateKernel(ex_policy, encloser),
@@ -114,7 +205,7 @@ ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::UpdateKernel::
       Vol_(encloser.dv_Vol_->DelegatedData(ex_policy)) {}
 //====================================================================================//
 template <class MaterialType, typename... Parameters>
-void ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
+void InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
     UpdateKernel::update(size_t index_i, Real dt)
 {
     Vecd conservative_force = Vecd::Zero();


### PR DESCRIPTION
I have restricted the continuum dynamics in SPHinXsim to inelastic materials only as the update Lagrangian formulation has no practical application for pure elastic problems. However, they are still kept in SPHinXsys as they can be used as reference for algorithm developing. 