### PR TITLE
add ductile damage model for J2 plasticity

### DIFF
--- a/sphinxsim/config/schemas.py
+++ b/sphinxsim/config/schemas.py
@@ -540,6 +540,47 @@ class ActiveStrainConfig(BaseModel):
     wavelength_factor: float = Field(..., gt=0)
     start_time: float = Field(..., gt=0)
 
+class DuctileDamageConfig(BaseModel):
+    enabled: bool = False
+
+    threshold_equivalent_plastic_strain: Optional[float] = Field(
+        default=None, ge=0.0
+    )
+
+    critical_equivalent_plastic_strain: Optional[float] = Field(
+        default=None, gt=0.0
+    )
+
+    critical_damage: Optional[float] = Field(
+        default=None, gt=0.0
+    )
+
+    @model_validator(mode="after")
+    def _validate_ductile_damage(self) -> "DuctileDamageConfig":
+        if not self.enabled:
+            return self
+
+        if (
+            self.threshold_equivalent_plastic_strain is None
+            or self.critical_equivalent_plastic_strain is None
+            or self.critical_damage is None
+        ):
+            raise ValueError(
+                "enabled ductile_damage requires "
+                "threshold_equivalent_plastic_strain, "
+                "critical_equivalent_plastic_strain and critical_damage"
+            )
+
+        if (
+            self.critical_equivalent_plastic_strain
+            <= self.threshold_equivalent_plastic_strain
+        ):
+            raise ValueError(
+                "critical_equivalent_plastic_strain must be greater than "
+                "threshold_equivalent_plastic_strain"
+            )
+
+        return self
 
 class MaterialConfig(BaseModel):
     type: MaterialType
@@ -556,6 +597,7 @@ class MaterialConfig(BaseModel):
     poisson_ratio: Optional[float] = None
     yield_stress: Optional[float] = Field(default=None, gt=0)
     hardening_modulus: Optional[float] = Field(default=None, gt=0)
+    ductile_damage: Optional[DuctileDamageConfig] = None
     friction_angle: Optional[float] = Field(default=None, ge=0)
     cohesion: Optional[float] = Field(default=None, ge=0)
     dilatancy_angle: Optional[float] = Field(default=None, ge=0)
@@ -716,6 +758,7 @@ class FluidBodyConfig(BaseModel):
 class SolidBodyConfig(BaseModel):
     name: str = Field(..., min_length=1)
     material: MaterialConfig
+    is_moving: bool = False
 
     @model_validator(mode="after")
     def _material_type(self) -> "SolidBodyConfig":

--- a/sphinxsim/sph_simulation/common_builder/material_builder.cpp
+++ b/sphinxsim/sph_simulation/common_builder/material_builder.cpp
@@ -109,8 +109,37 @@ void MaterialBuilder::addMatterMaterial(
         Real poisson_ratio = scaling_config.jsonToReal(config.at("poisson_ratio"), "Dimensionless");
         Real yield_stress = scaling_config.jsonToReal(config.at("yield_stress"), "Stress");
         Real hardening_modulus = scaling_config.jsonToReal(config.at("hardening_modulus"), "Stress");
+        
+        DuctileDamageParameters damage_parameters;
+        
+        if (config.contains("ductile_damage"))
+    {
+        const auto &damage_config = config.at("ductile_damage");
+
+        if (damage_config.contains("enabled"))
+            damage_parameters.enabled_ =
+                damage_config.at("enabled").get<bool>();
+
+        if (damage_config.contains("threshold_equivalent_plastic_strain"))
+            damage_parameters.threshold_equivalent_plastic_strain_ =
+                scaling_config.jsonToReal(
+                    damage_config.at("threshold_equivalent_plastic_strain"),
+                    "Dimensionless");
+
+        if (damage_config.contains("critical_equivalent_plastic_strain"))
+            damage_parameters.critical_equivalent_plastic_strain_ =
+                scaling_config.jsonToReal(
+                    damage_config.at("critical_equivalent_plastic_strain"),
+                    "Dimensionless");
+
+        if (damage_config.contains("critical_damage"))
+            damage_parameters.critical_damage_ =
+                scaling_config.jsonToReal(
+                    damage_config.at("critical_damage"),
+                    "Dimensionless");
+    }
         auto &material = sph_body.defineMatterMaterial<J2Plasticity>(
-            density, sound_speed, youngs_modulus, poisson_ratio, yield_stress, hardening_modulus);
+            density, sound_speed, youngs_modulus, poisson_ratio, yield_stress, hardening_modulus, damage_parameters);
         config_manager.addEntity(sph_body.Name() + "J2Plasticity", &material);
         return;
     }

--- a/sphinxsim/sph_simulation/dynamics_builder/constraint_builder.cpp
+++ b/sphinxsim/sph_simulation/dynamics_builder/constraint_builder.cpp
@@ -34,7 +34,7 @@ void ConstraintBuilder::addConstraint(
     if (sph_body_config.is_moving_ == false)
     {
         throw std::runtime_error(
-            "ConstraintBuilder::ConstraintBuilder: constrained body must be moving: ");
+            "ConstraintBuilder::ConstraintBuilder: constrained body must be moving: "+ real_body.Name());
     };
 
     const std::string type = config.at("type").get<std::string>();

--- a/sphinxsim/sphinxsys/src/shared/materials/general_continuum.cpp
+++ b/sphinxsim/sphinxsys/src/shared/materials/general_continuum.cpp
@@ -106,8 +106,8 @@ J2Plasticity::J2Plasticity(Real rho0, Real c0, Real youngs_modulus, Real poisson
                            Real yield_stress, Real hardening_modulus,const DuctileDamageParameters &damage_parameters)
     : GeneralContinuum(rho0, c0, youngs_modulus, poisson_ratio),
       yield_stress_(yield_stress), hardening_modulus_(hardening_modulus),
-      dv_hardening_factor_(nullptr), dv_intact_factor_(nullptr), dv_p_(nullptr),
-      failure_tension_(0.02 * youngs_modulus),dv_damage_(nullptr),damage_parameters_(damage_parameters)
+      dv_hardening_factor_(nullptr), dv_intact_factor_(nullptr), dv_p_(nullptr),dv_damage_(nullptr),
+      damage_parameters_(damage_parameters)
 {
     material_type_name_ = "J2Plasticity";
     if (damage_parameters_.enabled_)
@@ -186,12 +186,8 @@ void J2Plasticity::initializeLocalParameters(BaseParticles *base_particles)
      *      0 < D < Dc : damaging
      *      D = Dc      : rupture
      */
-    dv_damage_ =
-        base_particles->registerStateVariable<Real>(
-            "Damage", Real(0.0));
-
-    base_particles->addEvolvingVariable<Real>(
-        dv_damage_);
+    dv_damage_ =base_particles->registerStateVariable<Real>("Damage", Real(0.0));
+    base_particles->addEvolvingVariable<Real>(dv_damage_);
 }
 //=================================================================================================//
 } // namespace SPH

--- a/sphinxsim/sphinxsys/src/shared/materials/general_continuum.cpp
+++ b/sphinxsim/sphinxsys/src/shared/materials/general_continuum.cpp
@@ -106,8 +106,8 @@ J2Plasticity::J2Plasticity(Real rho0, Real c0, Real youngs_modulus, Real poisson
                            Real yield_stress, Real hardening_modulus,const DuctileDamageParameters &damage_parameters)
     : GeneralContinuum(rho0, c0, youngs_modulus, poisson_ratio),
       yield_stress_(yield_stress), hardening_modulus_(hardening_modulus),
-      dv_hardening_factor_(nullptr), dv_intact_factor_(nullptr), dv_p_(nullptr),dv_damage_(nullptr),
-      failure_tension_(0.02 * youngs_modulus),damage_parameters_(damage_parameters)
+      dv_hardening_factor_(nullptr), dv_intact_factor_(nullptr), dv_p_(nullptr),
+      failure_tension_(0.02 * youngs_modulus),dv_damage_(nullptr),damage_parameters_(damage_parameters)
 {
     material_type_name_ = "J2Plasticity";
     if (damage_parameters_.enabled_)

--- a/sphinxsim/sphinxsys/src/shared/materials/general_continuum.cpp
+++ b/sphinxsim/sphinxsys/src/shared/materials/general_continuum.cpp
@@ -2,6 +2,8 @@
 
 #include "base_particles.hpp"
 
+#include <stdexcept>
+
 namespace SPH
 {
 //=================================================================================================//
@@ -101,13 +103,29 @@ Mat3d PlasticContinuum::ReturnMapping(Mat3d &stress_tensor)
 }
 //=================================================================================================//
 J2Plasticity::J2Plasticity(Real rho0, Real c0, Real youngs_modulus, Real poisson_ratio,
-                           Real yield_stress, Real hardening_modulus)
+                           Real yield_stress, Real hardening_modulus,const DuctileDamageParameters &damage_parameters)
     : GeneralContinuum(rho0, c0, youngs_modulus, poisson_ratio),
       yield_stress_(yield_stress), hardening_modulus_(hardening_modulus),
-      dv_hardening_factor_(nullptr), dv_intact_factor_(nullptr), dv_p_(nullptr),
-      failure_tension_(0.02 * youngs_modulus)
+      dv_hardening_factor_(nullptr), dv_intact_factor_(nullptr), dv_p_(nullptr),dv_damage_(nullptr),
+      failure_tension_(0.02 * youngs_modulus),damage_parameters_(damage_parameters)
 {
     material_type_name_ = "J2Plasticity";
+    if (damage_parameters_.enabled_)
+    {
+        if (damage_parameters_.critical_equivalent_plastic_strain_ <=
+            damage_parameters_.threshold_equivalent_plastic_strain_)
+        {
+            throw std::invalid_argument(
+                "J2Plasticity: critical equivalent plastic strain "
+                "must be larger than threshold equivalent plastic strain.");
+        }
+
+        if (damage_parameters_.critical_damage_ <= Real(0))
+        {
+            throw std::invalid_argument(
+                "J2Plasticity: critical damage must be positive.");
+        }
+    }
 }
 //=================================================================================================//
 Matd J2Plasticity::ConstitutiveRelationShearStressWithHardening(Matd &velocity_gradient, Matd &shear_stress, Real &hardening_factor)
@@ -163,6 +181,17 @@ void J2Plasticity::initializeLocalParameters(BaseParticles *base_particles)
     base_particles->addEvolvingVariable<Real>(dv_p_);
     dv_intact_factor_ = base_particles->registerStateVariable<Real>("IntactFactor", Real(1.0));
     base_particles->addEvolvingVariable<Real>(dv_intact_factor_);
+    /** New ductile damage variable:
+     *      D = 0       : undamaged
+     *      0 < D < Dc : damaging
+     *      D = Dc      : rupture
+     */
+    dv_damage_ =
+        base_particles->registerStateVariable<Real>(
+            "Damage", Real(0.0));
+
+    base_particles->addEvolvingVariable<Real>(
+        dv_damage_);
 }
 //=================================================================================================//
 } // namespace SPH

--- a/sphinxsim/sphinxsys/src/shared/materials/general_continuum.h
+++ b/sphinxsim/sphinxsys/src/shared/materials/general_continuum.h
@@ -123,7 +123,19 @@ class PlasticContinuum : public GeneralContinuum
         inline Mat3d ReturnMapping(UnsignedInt index_i, Mat3d stress_tensor);
     };
 };
+struct DuctileDamageParameters
+{
+    bool enabled_ = false;
 
+    // Equivalent plastic strain at damage initiation
+    Real threshold_equivalent_plastic_strain_ = 0.0;
+
+    // Equivalent plastic strain at complete failure
+    Real critical_equivalent_plastic_strain_ = 1.0;
+
+    // Critical damage value
+    Real critical_damage_ = 1.0;
+};
 class J2Plasticity : public GeneralContinuum
 {
   protected:
@@ -134,10 +146,16 @@ class J2Plasticity : public GeneralContinuum
     DiscreteVariable<Real> *dv_intact_factor_;       // 1 for intact, 0 for fully failed
     DiscreteVariable<Real> *dv_p_, *dv_compression_; // for damage evaluation
     Real failure_tension_;                           // tension failure criterion
-
+    
+    // New ductile damage state variable.
+    DiscreteVariable<Real> *dv_damage_;
+    // Ductile damage material parameters
+    DuctileDamageParameters damage_parameters_;
   public:
     explicit J2Plasticity(Real rho0, Real c0, Real youngs_modulus, Real poisson_ratio,
-                          Real yield_stress, Real hardening_modulus = 0.0);
+                          Real yield_stress, Real hardening_modulus = 0.0,
+        const DuctileDamageParameters &damage_parameters =
+            DuctileDamageParameters{});
     virtual ~J2Plasticity() {};
     Real YieldStress() { return yield_stress_; };
     Real HardeningModulus() { return hardening_modulus_; };
@@ -163,9 +181,20 @@ class J2Plasticity : public GeneralContinuum
         Real hardening_modulus_;
         Real sqrt_2_over_3_, failure_tension_;
         Real *hardening_factor_, *intact_factor_, *p_, *compression_;
+        Real *damage_;
+        /** Ductile-damage parameters copied to the compute kernel. */
+        bool damage_enabled_;
+        Real damage_threshold_equivalent_plastic_strain_;
+        Real damage_critical_equivalent_plastic_strain_;
+        Real critical_damage_;   
 
         inline Matd ReturnMapping(UnsignedInt index_i, Matd try_shear_stress);
         inline Real HardeningFactorRate(const Matd &shear_stress, Real &hardening_factor);
+        /** Eq. (39) + Eq. (40). */
+        inline void updateDuctileDamage(
+            UnsignedInt index_i,
+            const Matd &updated_shear_stress,
+            Real delta_equivalent_plastic_strain);
     };
 };
 } // namespace SPH

--- a/sphinxsim/sphinxsys/src/shared/materials/general_continuum.h
+++ b/sphinxsim/sphinxsys/src/shared/materials/general_continuum.h
@@ -126,13 +126,10 @@ class PlasticContinuum : public GeneralContinuum
 struct DuctileDamageParameters
 {
     bool enabled_ = false;
-
     // Equivalent plastic strain at damage initiation
     Real threshold_equivalent_plastic_strain_ = 0.0;
-
     // Equivalent plastic strain at complete failure
     Real critical_equivalent_plastic_strain_ = 1.0;
-
     // Critical damage value
     Real critical_damage_ = 1.0;
 };
@@ -145,7 +142,6 @@ class J2Plasticity : public GeneralContinuum
     DiscreteVariable<Real> *dv_hardening_factor_;
     DiscreteVariable<Real> *dv_intact_factor_;       // 1 for intact, 0 for fully failed
     DiscreteVariable<Real> *dv_p_, *dv_compression_; // for damage evaluation
-    Real failure_tension_;                           // tension failure criterion
     
     // New ductile damage state variable.
     DiscreteVariable<Real> *dv_damage_;
@@ -179,7 +175,7 @@ class J2Plasticity : public GeneralContinuum
       protected:
         Real yield_stress_;
         Real hardening_modulus_;
-        Real sqrt_2_over_3_, failure_tension_;
+        Real sqrt_2_over_3_;
         Real *hardening_factor_, *intact_factor_, *p_, *compression_;
         Real *damage_;
         /** Ductile-damage parameters copied to the compute kernel. */
@@ -190,11 +186,7 @@ class J2Plasticity : public GeneralContinuum
 
         inline Matd ReturnMapping(UnsignedInt index_i, Matd try_shear_stress);
         inline Real HardeningFactorRate(const Matd &shear_stress, Real &hardening_factor);
-        /** Eq. (39) + Eq. (40). */
-        inline void updateDuctileDamage(
-            UnsignedInt index_i,
-            const Matd &updated_shear_stress,
-            Real delta_equivalent_plastic_strain);
+        inline void updateDuctileDamage(UnsignedInt index_i,const Matd &updated_shear_stress,Real delta_equivalent_plastic_strain);
     };
 };
 } // namespace SPH

--- a/sphinxsim/sphinxsys/src/shared/materials/general_continuum.hpp
+++ b/sphinxsim/sphinxsys/src/shared/materials/general_continuum.hpp
@@ -110,8 +110,24 @@ J2Plasticity::ConstituteKernel::
       yield_stress_(encloser.yield_stress_),
       hardening_modulus_(encloser.hardening_modulus_),
       sqrt_2_over_3_(encloser.sqrt_2_over_3_), failure_tension_(encloser.failure_tension_),
+      damage_enabled_(
+          encloser.damage_parameters_.enabled_),
+
+      damage_threshold_equivalent_plastic_strain_(
+          encloser.damage_parameters_
+              .threshold_equivalent_plastic_strain_),
+
+      damage_critical_equivalent_plastic_strain_(
+          encloser.damage_parameters_
+              .critical_equivalent_plastic_strain_),
+
+      critical_damage_(
+          encloser.damage_parameters_.critical_damage_),
       hardening_factor_(encloser.dv_hardening_factor_->DelegatedData(ex_policy)),
       intact_factor_(encloser.dv_intact_factor_->DelegatedData(ex_policy)),
+      damage_(
+          encloser.dv_damage_
+              ->DelegatedData(ex_policy)),
       p_(encloser.dv_p_->DelegatedData(ex_policy)),
       compression_(encloser.dv_compression_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
@@ -137,9 +153,95 @@ Matd J2Plasticity::ConstituteKernel::updateShearStress(
     UnsignedInt index_i, const Matd &try_shear_stress)
 {
     Real hardening_factor_increment = HardeningFactorRate(try_shear_stress, hardening_factor_[index_i]);
-    hardening_factor_[index_i] += sqrt(2.0 / 3.0) * hardening_factor_increment;
-    return ReturnMapping(index_i, try_shear_stress);
+    // hardening_factor_[index_i] += sqrt(2.0 / 3.0) * hardening_factor_increment;
+    Real delta_equivalent_plastic_strain =sqrt(2.0 / 3.0) * hardening_factor_increment;
+    hardening_factor_[index_i] +=delta_equivalent_plastic_strain;
+    
+    Matd updated_shear_stress =
+        ReturnMapping(
+            index_i,
+            try_shear_stress);
+
+    updateDuctileDamage(
+        index_i,
+        updated_shear_stress,
+        delta_equivalent_plastic_strain);
+
+    return updated_shear_stress;    
+    // return ReturnMapping(index_i, try_shear_stress);
 }
+//=================================================================================================//
+void J2Plasticity::ConstituteKernel::updateDuctileDamage(
+    UnsignedInt index_i,
+    const Matd &updated_shear_stress,
+    Real delta_equivalent_plastic_strain)
+{
+    if (!damage_enabled_)
+        return;
+
+    if (delta_equivalent_plastic_strain <= TinyReal)
+        return;
+
+    if (damage_[index_i] >= critical_damage_)
+        return;
+
+    // J2 = 1/2 s:s
+    Real stress_tensor_J2 =
+        0.5 *
+        (updated_shear_stress.cwiseProduct(
+             updated_shear_stress.transpose()))
+            .sum();
+
+    // Von Mises equivalent stress: sigma_eq = sqrt(3 J2)
+    Real equivalent_stress =
+        sqrt(3.0 * stress_tensor_J2);
+
+    if (equivalent_stress <= TinyReal)
+        return;
+
+    // sigma = s - pI  -> sigma_H = -p
+    Real hydrostatic_stress =
+        -p_[index_i];
+
+    Real stress_triaxiality =
+        hydrostatic_stress /
+        equivalent_stress;
+
+    // R_nu in Eq. (39) and Eq. (40)
+    Real damage_weight =
+        (2.0 / 3.0) * (1.0 + nu_) +
+        3.0 * (1.0 - 2.0 * nu_) *
+            stress_triaxiality *
+            stress_triaxiality;
+
+    // Existing HardeningFactor is accumulated equivalent plastic strain
+    Real equivalent_plastic_strain =
+        hardening_factor_[index_i];
+
+    // Eq. (39)
+    Real damage_function =
+        damage_weight *
+            equivalent_plastic_strain -
+        damage_threshold_equivalent_plastic_strain_;
+
+    if (damage_function < Real(0))
+        return;
+
+    // Incremental Eq. (40)
+    Real damage_increment =
+        critical_damage_ /
+        (damage_critical_equivalent_plastic_strain_ -
+         damage_threshold_equivalent_plastic_strain_) *
+        damage_weight *
+        delta_equivalent_plastic_strain;
+
+    damage_[index_i] =
+        SMIN(
+            critical_damage_,
+            damage_[index_i] +
+                SMAX(damage_increment, Real(0)));
+}
+
 //=================================================================================================//
 Real J2Plasticity::ConstituteKernel::ScalePenaltyForce(UnsignedInt index_i, const Matd &try_shear_stress)
 {
@@ -159,6 +261,11 @@ void J2Plasticity::ConstituteKernel::updateIntactFactor(UnsignedInt index_i)
     Real alpha = 0.8;
     Real p_diff = p_[index_i] + alpha * failure_tension_;
     Real try_intact_factor = SMAX(1.0 + p_diff / ((1.0 - alpha) * failure_tension_), 0.0);
+    if (damage_enabled_ &&
+        damage_[index_i] >= critical_damage_)
+    {
+        try_intact_factor = Real(0);
+    }
     intact_factor_[index_i] = SMIN(intact_factor_[index_i], try_intact_factor); // damage is irreversible
     compression_[index_i] = // not less than 1.0 after failure
         SMAX(compression_[index_i], Real(1) + (compression_[index_i] - Real(1)) * intact_factor_[index_i]);

--- a/sphinxsim/sphinxsys/src/shared/materials/general_continuum.hpp
+++ b/sphinxsim/sphinxsys/src/shared/materials/general_continuum.hpp
@@ -109,27 +109,28 @@ J2Plasticity::ConstituteKernel::
     : GeneralContinuum::ConstituteKernel(ex_policy, encloser),
       yield_stress_(encloser.yield_stress_),
       hardening_modulus_(encloser.hardening_modulus_),
-      sqrt_2_over_3_(encloser.sqrt_2_over_3_), failure_tension_(encloser.failure_tension_),
+      sqrt_2_over_3_(encloser.sqrt_2_over_3_),
+      failure_tension_(encloser.failure_tension_),
+      hardening_factor_(
+          encloser.dv_hardening_factor_->DelegatedData(ex_policy)),
+      intact_factor_(
+          encloser.dv_intact_factor_->DelegatedData(ex_policy)),
+      p_(
+          encloser.dv_p_->DelegatedData(ex_policy)),
+      compression_(
+          encloser.dv_compression_->DelegatedData(ex_policy)),
+      damage_(
+          encloser.dv_damage_->DelegatedData(ex_policy)),
       damage_enabled_(
           encloser.damage_parameters_.enabled_),
-
       damage_threshold_equivalent_plastic_strain_(
-          encloser.damage_parameters_
-              .threshold_equivalent_plastic_strain_),
-
+          encloser.damage_parameters_.threshold_equivalent_plastic_strain_),
       damage_critical_equivalent_plastic_strain_(
-          encloser.damage_parameters_
-              .critical_equivalent_plastic_strain_),
-
+          encloser.damage_parameters_.critical_equivalent_plastic_strain_),
       critical_damage_(
-          encloser.damage_parameters_.critical_damage_),
-      hardening_factor_(encloser.dv_hardening_factor_->DelegatedData(ex_policy)),
-      intact_factor_(encloser.dv_intact_factor_->DelegatedData(ex_policy)),
-      damage_(
-          encloser.dv_damage_
-              ->DelegatedData(ex_policy)),
-      p_(encloser.dv_p_->DelegatedData(ex_policy)),
-      compression_(encloser.dv_compression_->DelegatedData(ex_policy)) {}
+          encloser.damage_parameters_.critical_damage_)
+{
+}
 //=================================================================================================//
 Matd J2Plasticity::ConstituteKernel::ShearStressRate(
     UnsignedInt index_i, const Matd &velocity_gradient, const Matd &shear_stress)

--- a/sphinxsim/sphinxsys/src/shared/materials/general_continuum.hpp
+++ b/sphinxsim/sphinxsys/src/shared/materials/general_continuum.hpp
@@ -110,7 +110,6 @@ J2Plasticity::ConstituteKernel::
       yield_stress_(encloser.yield_stress_),
       hardening_modulus_(encloser.hardening_modulus_),
       sqrt_2_over_3_(encloser.sqrt_2_over_3_),
-      failure_tension_(encloser.failure_tension_),
       hardening_factor_(
           encloser.dv_hardening_factor_->DelegatedData(ex_policy)),
       intact_factor_(
@@ -154,22 +153,12 @@ Matd J2Plasticity::ConstituteKernel::updateShearStress(
     UnsignedInt index_i, const Matd &try_shear_stress)
 {
     Real hardening_factor_increment = HardeningFactorRate(try_shear_stress, hardening_factor_[index_i]);
-    // hardening_factor_[index_i] += sqrt(2.0 / 3.0) * hardening_factor_increment;
     Real delta_equivalent_plastic_strain =sqrt(2.0 / 3.0) * hardening_factor_increment;
     hardening_factor_[index_i] +=delta_equivalent_plastic_strain;
     
-    Matd updated_shear_stress =
-        ReturnMapping(
-            index_i,
-            try_shear_stress);
-
-    updateDuctileDamage(
-        index_i,
-        updated_shear_stress,
-        delta_equivalent_plastic_strain);
-
+    Matd updated_shear_stress =ReturnMapping(index_i,try_shear_stress);
+    updateDuctileDamage(index_i,updated_shear_stress,delta_equivalent_plastic_strain);
     return updated_shear_stress;    
-    // return ReturnMapping(index_i, try_shear_stress);
 }
 //=================================================================================================//
 void J2Plasticity::ConstituteKernel::updateDuctileDamage(
@@ -177,70 +166,24 @@ void J2Plasticity::ConstituteKernel::updateDuctileDamage(
     const Matd &updated_shear_stress,
     Real delta_equivalent_plastic_strain)
 {
-    if (!damage_enabled_)
-        return;
+    if (!damage_enabled_) return;
+    if (delta_equivalent_plastic_strain <= TinyReal) return;
+    if (damage_[index_i] >= critical_damage_) return;
 
-    if (delta_equivalent_plastic_strain <= TinyReal)
-        return;
+    Real stress_tensor_J2 =0.5 *(updated_shear_stress.cwiseProduct(updated_shear_stress.transpose())).sum();
+    Real equivalent_stress =sqrt(3.0 * stress_tensor_J2);
+    
+    if (equivalent_stress <= TinyReal) return;
 
-    if (damage_[index_i] >= critical_damage_)
-        return;
+    Real hydrostatic_stress =-p_[index_i];
+    Real stress_triaxiality =hydrostatic_stress /equivalent_stress;
+    Real damage_weight =(2.0 / 3.0) * (1.0 + nu_) +3.0 * (1.0 - 2.0 * nu_) *stress_triaxiality *stress_triaxiality;
+    Real equivalent_plastic_strain =hardening_factor_[index_i];
+    Real damage_function =damage_weight *equivalent_plastic_strain -damage_threshold_equivalent_plastic_strain_;
+    if (damage_function < Real(0)) return;
 
-    // J2 = 1/2 s:s
-    Real stress_tensor_J2 =
-        0.5 *
-        (updated_shear_stress.cwiseProduct(
-             updated_shear_stress.transpose()))
-            .sum();
-
-    // Von Mises equivalent stress: sigma_eq = sqrt(3 J2)
-    Real equivalent_stress =
-        sqrt(3.0 * stress_tensor_J2);
-
-    if (equivalent_stress <= TinyReal)
-        return;
-
-    // sigma = s - pI  -> sigma_H = -p
-    Real hydrostatic_stress =
-        -p_[index_i];
-
-    Real stress_triaxiality =
-        hydrostatic_stress /
-        equivalent_stress;
-
-    // R_nu in Eq. (39) and Eq. (40)
-    Real damage_weight =
-        (2.0 / 3.0) * (1.0 + nu_) +
-        3.0 * (1.0 - 2.0 * nu_) *
-            stress_triaxiality *
-            stress_triaxiality;
-
-    // Existing HardeningFactor is accumulated equivalent plastic strain
-    Real equivalent_plastic_strain =
-        hardening_factor_[index_i];
-
-    // Eq. (39)
-    Real damage_function =
-        damage_weight *
-            equivalent_plastic_strain -
-        damage_threshold_equivalent_plastic_strain_;
-
-    if (damage_function < Real(0))
-        return;
-
-    // Incremental Eq. (40)
-    Real damage_increment =
-        critical_damage_ /
-        (damage_critical_equivalent_plastic_strain_ -
-         damage_threshold_equivalent_plastic_strain_) *
-        damage_weight *
-        delta_equivalent_plastic_strain;
-
-    damage_[index_i] =
-        SMIN(
-            critical_damage_,
-            damage_[index_i] +
-                SMAX(damage_increment, Real(0)));
+    Real damage_increment =critical_damage_ /(damage_critical_equivalent_plastic_strain_ -damage_threshold_equivalent_plastic_strain_) *damage_weight *delta_equivalent_plastic_strain;
+    damage_[index_i] =SMIN(critical_damage_,damage_[index_i] + SMAX(damage_increment, Real(0)));
 }
 
 //=================================================================================================//
@@ -259,14 +202,10 @@ Real J2Plasticity::ConstituteKernel::ScalePenaltyForce(UnsignedInt index_i, cons
 //=================================================================================================//
 void J2Plasticity::ConstituteKernel::updateIntactFactor(UnsignedInt index_i)
 {
-    Real alpha = 0.8;
-    Real p_diff = p_[index_i] + alpha * failure_tension_;
-    Real try_intact_factor = SMAX(1.0 + p_diff / ((1.0 - alpha) * failure_tension_), 0.0);
-    if (damage_enabled_ &&
-        damage_[index_i] >= critical_damage_)
-    {
-        try_intact_factor = Real(0);
-    }
+    if (!damage_enabled_)
+        return;
+    Real try_intact_factor = SMAX(Real(1.0) - damage_[index_i] / critical_damage_, Real(0.0));
+    
     intact_factor_[index_i] = SMIN(intact_factor_[index_i], try_intact_factor); // damage is irreversible
     compression_[index_i] = // not less than 1.0 after failure
         SMAX(compression_[index_i], Real(1) + (compression_[index_i] - Real(1)) * intact_factor_[index_i]);

--- a/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_factor.hpp
+++ b/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_factor.hpp
@@ -21,7 +21,7 @@ template <typename... Parameters>
 template <class DynamicsIdentifier>
 RepulsionFactor<Contact<Parameters...>>::
     RepulsionFactor(DynamicsIdentifier &identifier)
-    : BaseInteractionType(identifier, "RepulsionFactor")
+    : BaseInteractionType(identifier, "RepulsionFactor" + identifier.Name())
 {
     for (size_t k = 0; k != this->contact_particles_.size(); ++k)
     {

--- a/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_force.hpp
+++ b/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_force.hpp
@@ -38,7 +38,7 @@ RepulsionForceCK<Contact<WithUpdate, Parameters...>>::
         contact_stiffness_.push_back(solid.ContactStiffness());
         contact_impedance_.push_back(sqrt(solid.ReferenceDensity() * solid.ContactStiffness()));
         dv_contact_repulsion_factor_.push_back(
-            this->contact_particles_[k]->template getVariableByName<Real>("RepulsionFactor")); //not implemented yet
+            this->contact_particles_[k]->template getVariableByName<Real>("RepulsionFactor")); 
         dv_contact_vel_.push_back(
             this->contact_particles_[k]->template getVariableByName<Vecd>("Velocity"));
         dv_contact_n_.push_back(

--- a/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_force.hpp
+++ b/sphinxsim/sphinxsys/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_force.hpp
@@ -14,12 +14,13 @@ template <class DynamicsIdentifier>
 RepulsionForceCK<Base, Contact<Parameters...>>::
     RepulsionForceCK(DynamicsIdentifier &identifier, Real numerical_damping)
     : Interaction<Contact<Parameters...>>(identifier),
-      ForcePriorCK(this->particles_, "RepulsionForce"),
+      ForcePriorCK(this->particles_, "RepulsionForce" + identifier.Name()),
       solid_contact_(DynamicCast<SolidContact>(this, this->sph_body_->getMatterMaterial())),
       numerical_damping_(numerical_damping),
       stiffness_(solid_contact_.ContactStiffness()),
       impedance_(sqrt(solid_contact_.ContactReferenceDensity() * stiffness_)),
-      dv_repulsion_factor_(this->particles_->template getVariableByName<Real>("RepulsionFactor")),
+      dv_repulsion_factor_(this->particles_->template getVariableByName<Real>(
+          "RepulsionFactor" + identifier.Name())),
       dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure")),
       dv_vel_(this->particles_->template getVariableByName<Vecd>("Velocity")),
       dv_repulsion_force_(ForcePriorCK::getCurrentForce()) {}
@@ -37,7 +38,7 @@ RepulsionForceCK<Contact<WithUpdate, Parameters...>>::
         contact_stiffness_.push_back(solid.ContactStiffness());
         contact_impedance_.push_back(sqrt(solid.ReferenceDensity() * solid.ContactStiffness()));
         dv_contact_repulsion_factor_.push_back(
-            this->contact_particles_[k]->template getVariableByName<Real>("RepulsionFactor"));
+            this->contact_particles_[k]->template getVariableByName<Real>("RepulsionFactor")); //not implemented yet
         dv_contact_vel_.push_back(
             this->contact_particles_[k]->template getVariableByName<Vecd>("Velocity"));
         dv_contact_n_.push_back(

--- a/tests/test_simulation/test_2d_simulation/data/milling.json
+++ b/tests/test_simulation/test_2d_simulation/data/milling.json
@@ -1,10 +1,5 @@
 {
   "geometries": {
-    "system_domain": {
-      "upper_bound": [0.16, 0.08],
-      "lower_bound": [-0.16, -0.16]
-    },
-
     "global_resolution": {
       "particle_spacing": 0.0008
     },
@@ -39,10 +34,10 @@
           {
             "operation": "union",
             "type": "container_box",
-            "inner_lower_bound": [-0.10, -0.10],
-            "inner_upper_bound": [0.10, 0.05],
+            "inner_lower_bound": [-0.07, -0.08],
+            "inner_upper_bound": [0.13, 0.07],
             "thickness": 0.0032
-           }
+          }
         ]
       }
     ],
@@ -105,7 +100,7 @@
         "ductile_damage": {
           "enabled": true,
           "threshold_equivalent_plastic_strain": 0.15,
-          "critical_equivalent_plastic_strain": 0.50,
+          "critical_equivalent_plastic_strain": 0.5,
           "critical_damage": 1.0
         }
       }
@@ -126,17 +121,17 @@
       "material": {
         "type": "rigid_body"
       }
-    }    
+    }
   ],
 
-  "gravity": [0.0, -9.8],
+  "gravity": [0.0, -9.8e-3],
 
   "body_constraints": [
     {
       "body_name": "MillingTool",
       "type": "simbody",
       "mobilized_body": "planar",
-      "velocity": [0.0, -0.005],
+      "velocity": [0.0, -0.03],
       "angular_velocity": 2.0
     },
 
@@ -152,17 +147,9 @@
       "name": "ProcessingPiece",
       "variables": [
         {
-          "real_type": [
-            "Pressure",
-            "IntactFactor",
-            "HardeningFactor",
-            "Damage",
-            "Compression"
-          ],
+          "real_type": ["Pressure", "IntactFactor", "HardeningFactor", "Damage", "Compression"],
 
-          "vector_type": [
-            "HourglassStressDivergence"
-          ]
+          "vector_type": ["HourglassStressDivergence"]
         }
       ]
     },
@@ -171,19 +158,15 @@
       "name": "MillingTool",
       "variables": [
         {
-          "vector_type": [
-            "NormalDirection",
-            "Velocity"
-          ]
+          "vector_type": ["NormalDirection", "Velocity"]
         }
       ]
     }
-
   ],
 
   "solver_parameters": {
-    "end_time": 0.1,
-    "output_interval": 0.03,
+    "end_time": 1.0,
+    "output_interval": 0.01,
     "screen_interval": 100,
 
     "continuum_dynamics": {

--- a/tests/test_simulation/test_2d_simulation/data/milling.json
+++ b/tests/test_simulation/test_2d_simulation/data/milling.json
@@ -1,10 +1,14 @@
 {
   "geometries": {
     "system_domain": {
-      "upper_bound": [0.08, 0.04],
-      "lower_bound": [-0.08, -0.08]
+      "upper_bound": [0.16, 0.08],
+      "lower_bound": [-0.16, -0.16]
     },
-    "global_resolution": { "particle_spacing": 0.0008 },
+
+    "global_resolution": {
+      "particle_spacing": 0.0008
+    },
+
     "shapes": [
       {
         "name": "ProcessingPiece",
@@ -15,6 +19,7 @@
           "rotation_angle": 0.0
         }
       },
+
       {
         "name": "MillingTool",
         "type": "multipolygon",
@@ -25,8 +30,23 @@
             "file_name": "milling_tool.dat"
           }
         ]
+      },
+
+      {
+        "name": "WallBoundary",
+        "type": "multipolygon",
+        "polygons": [
+          {
+            "operation": "union",
+            "type": "container_box",
+            "inner_lower_bound": [-0.10, -0.10],
+            "inner_upper_bound": [0.10, 0.05],
+            "thickness": 0.0032
+           }
+        ]
       }
     ],
+
     "oriented_boxes": [
       {
         "name": "ClampingRegion",
@@ -47,12 +67,21 @@
         {
           "name": "ProcessingPiece"
         },
+
         {
           "name": "MillingTool",
           "solid_body": {},
-          "relaxation": { "level_set": {} }
+          "relaxation": {
+            "level_set": {}
+          }
+        },
+
+        {
+          "name": "WallBoundary",
+          "solid_body": {}
         }
       ],
+
       "relaxation_parameters": {
         "total_iterations": 1000
       }
@@ -71,29 +100,46 @@
         "youngs_modulus": 78.2e2,
         "poisson_ratio": 0.3,
         "yield_stress": 2.9e1,
-        "hardening_modulus": 1.0
+        "hardening_modulus": 1.0,
+
+        "ductile_damage": {
+          "enabled": true,
+          "threshold_equivalent_plastic_strain": 0.15,
+          "critical_equivalent_plastic_strain": 0.50,
+          "critical_damage": 1.0
+        }
       }
     }
   ],
 
   "solid_bodies": [
     {
+      "name": "WallBoundary",
+      "material": {
+        "type": "rigid_body"
+      }
+    },
+
+    {
       "name": "MillingTool",
       "is_moving": true,
       "material": {
         "type": "rigid_body"
       }
-    }
+    }    
   ],
+
+  "gravity": [0.0, -9.8],
 
   "body_constraints": [
     {
       "body_name": "MillingTool",
       "type": "simbody",
       "mobilized_body": "planar",
-      "velocity": [0.0, -0.03],
+      "velocity": [0.0, -0.005],
       "angular_velocity": 2.0
     },
+
     {
       "body_name": "ProcessingPiece",
       "type": "fixed",
@@ -106,21 +152,40 @@
       "name": "ProcessingPiece",
       "variables": [
         {
-          "real_type": ["Pressure", "IntactFactor", "Compression"],
-          "vector_type": ["HourglassStressDivergence"]
+          "real_type": [
+            "Pressure",
+            "IntactFactor",
+            "HardeningFactor",
+            "Damage",
+            "Compression"
+          ],
+
+          "vector_type": [
+            "HourglassStressDivergence"
+          ]
         }
       ]
     },
+
     {
       "name": "MillingTool",
-      "variables": [{ "vector_type": ["NormalDirection", "Velocity"] }]
+      "variables": [
+        {
+          "vector_type": [
+            "NormalDirection",
+            "Velocity"
+          ]
+        }
+      ]
     }
+
   ],
 
   "solver_parameters": {
-    "end_time": 0.3,
+    "end_time": 2.2,
     "output_interval": 0.01,
     "screen_interval": 100,
+
     "continuum_dynamics": {
       "acoustic_cfl": 0.4,
       "advection_cfl": 0.2,

--- a/tests/test_simulation/test_2d_simulation/data/milling.json
+++ b/tests/test_simulation/test_2d_simulation/data/milling.json
@@ -183,7 +183,7 @@
 
   "solver_parameters": {
     "end_time": 0.1,
-    "output_interval": 0.01,
+    "output_interval": 0.03,
     "screen_interval": 100,
 
     "continuum_dynamics": {

--- a/tests/test_simulation/test_2d_simulation/data/milling.json
+++ b/tests/test_simulation/test_2d_simulation/data/milling.json
@@ -1,5 +1,10 @@
 {
   "geometries": {
+    "system_domain": {
+      "upper_bound": [0.16, 0.08],
+      "lower_bound": [-0.16, -0.16]
+    },
+
     "global_resolution": {
       "particle_spacing": 0.0008
     },
@@ -124,7 +129,7 @@
     }
   ],
 
-  "gravity": [0.0, -9.8e-3],
+  "gravity": [0.0, -9.8e-4],
 
   "body_constraints": [
     {

--- a/tests/test_simulation/test_2d_simulation/data/milling.json
+++ b/tests/test_simulation/test_2d_simulation/data/milling.json
@@ -182,7 +182,7 @@
   ],
 
   "solver_parameters": {
-    "end_time": 2.2,
+    "end_time": 0.1,
     "output_interval": 0.01,
     "screen_interval": 100,
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/233c1720-e996-4617-b07a-07a6133125d9

I believe the issue of **superimposing multiple contact forces when the J2 material interacts simultaneously with the two rigid bodies, `MillingTool` and `WallBoundary`, has not yet been fully resolved**. In particular, after the material undergoes damage, it is necessary to further clarify how the material state of the damaged particles should be updated and which material/contact model should be adopted after failure to ensure physically reasonable contact interactions with the `WallBoundary`.
