### PR TITLE
only add float accuracy check

### DIFF
--- a/sphinxsim/sph_simulation/common_builder/geometry_builder.cpp
+++ b/sphinxsim/sph_simulation/common_builder/geometry_builder.cpp
@@ -189,6 +189,19 @@ SystemDomainConfig GeometryBuilder::parseSystemDomainConfig(
         system_config.system_bounds_ = parseBoundingBox(scaling_config, config.at("system_domain"));
     }
     system_config.particle_spacing_ = parseGlobalResolution(scaling_config, config.at("global_resolution"));
+
+#if SPHINXSYS_USE_FLOAT
+    if (std::pow(system_config.particle_spacing_, Dimensions) < 1.0e-6)
+    {
+        std::cout << "\n------------------------------------------------------------" << std::endl;
+        std::cout << "Error: particle spacing is too small for float precision!" << std::endl;
+        std::cout << "The particle volume measure is less than 1.0e-6." << std::endl;
+        std::cout << "Please use characteristic scaling for the simulation." << std::endl;
+        std::cout << "------------------------------------------------------------" << std::endl;
+        exit(1);
+    }
+#endif
+
     return system_config;
 }
 //=================================================================================================//

--- a/sphinxsim/sph_simulation/simulation_builder/simulation_scaling.cpp
+++ b/sphinxsim/sph_simulation/simulation_builder/simulation_scaling.cpp
@@ -157,6 +157,12 @@ ScalingConfig::ScalingConfig(const json &config)
     bool user_scaling_provided = false;
     if (config.contains("characteristic_dimensions"))
     {
+        if (config.at("characteristic_dimensions").size() < 2)
+        {
+            throw std::runtime_error(
+                "ScalingConfig::ScalingConfig: At least two different characteristic dimensions must be provided.");
+        }
+
         bool has_length_unit = false;
         for (const auto &cd : config.at("characteristic_dimensions"))
         {
@@ -276,12 +282,24 @@ CharacteristicDimension ScalingConfig::parseCharacteristicDimension(
     else
     {
         character_dim.hint_ = config.at("hint").get<std::string>();
-        Real hint_value = resolve(root_config, character_dim.hint_);
-        if (!isSameOrderOfMagnitude(character_dim.value_, hint_value))
+        if (character_dim.hint_ == "externally_defined")
         {
-            throw std::runtime_error(
-                "ScalingConfig::parseCharacteristicDimension: value of '" + character_dim.name_ +
-                "' is not the same order of magnitude as its hint '" + character_dim.hint_ + "'.");
+            std::cout << "\n------------------------------------------------------------" << std::endl;
+            std::cout << "Warning: hint for '" << character_dim.name_ << "' is externally defined. " << std::endl;
+            std::cout << "Considering using a hint defined in the configuration file to avoid ambiguity." << std::endl;
+            std::cout << "------------------------------------------------------------" << std::endl;
+
+            return character_dim;
+        }
+        else
+        {
+            Real hint_value = resolve(root_config, character_dim.hint_);
+            if (!isSameOrderOfMagnitude(character_dim.value_, hint_value))
+            {
+                throw std::runtime_error(
+                    "ScalingConfig::parseCharacteristicDimension: value of '" + character_dim.name_ +
+                    "' is not the same order of magnitude as its hint '" + character_dim.hint_ + "'.");
+            }
         }
     }
     return character_dim;

--- a/tests/test_simulation/test_2d_simulation/data/milling.json
+++ b/tests/test_simulation/test_2d_simulation/data/milling.json
@@ -1,4 +1,17 @@
-{
+{  
+  "characteristic_dimensions": [
+    {
+      "value": 0.02,
+      "name": "Length",
+      "hint": "geometries.shapes[name=ProcessingPiece].half_size"
+    },
+    {
+      "value": 1.0,
+      "name": "Velocity",
+      "hint": "externally_defined"
+    }
+  ],
+
   "geometries": {
     "system_domain": {
       "upper_bound": [0.08, 0.04],

--- a/tests/test_simulation/test_3d_simulation/data/repose_angle.json
+++ b/tests/test_simulation/test_3d_simulation/data/repose_angle.json
@@ -1,4 +1,22 @@
 {
+  "characteristic_dimensions": [
+    {
+      "value": 0.1,
+      "name": "Length",
+      "hint": "geometries.shapes[name=GranularBody].radius"
+    },
+    {
+      "value": 9.8,
+      "name": "Gravity",
+      "hint": "gravity"
+    },
+    {
+      "value": 2600.0,
+      "name": "Density",
+      "hint": "continuum_bodies[name=GranularBody].material.density"
+    }
+  ],
+
   "simulation_type": "continuum_dynamics",
 
   "geometries": {


### PR DESCRIPTION
This pull request introduces several improvements to the simulation configuration validation and error handling, particularly around scaling and characteristic dimensions. It adds new checks and warnings to prevent common user errors and clarifies configuration requirements. Additionally, the test data is updated to reflect and test these new behaviors.

**Validation and error handling improvements:**

* Added a check in `ScalingConfig::ScalingConfig` to ensure that at least two characteristic dimensions are provided in the configuration, throwing a runtime error if not.
* In `GeometryBuilder::parseSystemDomainConfig`, added a check (enabled when using float precision) to ensure that the computed particle volume is not too small, printing an error and exiting if it is, to avoid numerical issues.
* In `ScalingConfig::parseCharacteristicDimension`, added a warning if the `hint` for a characteristic dimension is set to `"externally_defined"`, advising users to provide a more explicit hint to avoid ambiguity. [[1]](diffhunk://#diff-7b4d25dbea1f58b884c5e68d498cf4539373122f741f216e59795381f643b723R285-R295) [[2]](diffhunk://#diff-7b4d25dbea1f58b884c5e68d498cf4539373122f741f216e59795381f643b723R304)

**Test data updates:**

* Updated `test_2d_simulation/data/milling.json` to include two characteristic dimensions, one of which uses the `"externally_defined"` hint, ensuring the new warning and validation logic is exercised.
* Updated `test_3d_simulation/data/repose_angle.json` to provide three characteristic dimensions, each with explicit hints, supporting the improved validation.