### PR TITLE
done

### DIFF
--- a/sphinxsim/sph_simulation/dynamics_builder/continuum_dynamics/continuum_dynamics_builder.cpp
+++ b/sphinxsim/sph_simulation/dynamics_builder/continuum_dynamics/continuum_dynamics_builder.cpp
@@ -189,22 +189,19 @@ void ContinuumDynamicsBuilder::buildContactRepulsionIfPresent(
                 }
             }
 
-            if (config_manager.hasEntity<SPHBodiesConfig>("SolidBodiesConfig"))
+            auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
+            for (const auto &sb_tgt : solid_bodies_config)
             {
-                auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
-                for (const auto &sb_tgt : solid_bodies_config)
-                {
-                    std::string relation_name = body_name + sb_tgt->name_;
-                    auto &contact_relation = sph_system.getRelationByName<
-                        Contact<Relation<RealBody, SolidBody>>>(relation_name);
-                    contact_repulsion_factor.add(
-                        &main_methods.template addInteractionDynamics<solid_dynamics::RepulsionFactor>(
-                            contact_relation));
-                    contact_repulsion_force.add(
-                        &main_methods.template addInteractionDynamicsWithUpdate<
-                            solid_dynamics::RepulsionForceCK, Wall>(
-                            contact_relation, continuum_solver_parameters.contact_numerical_damping_));
-                }
+                std::string relation_name = body_name + sb_tgt->name_;
+                auto &contact_relation = sph_system.getRelationByName<
+                    Contact<Relation<RealBody, SolidBody>>>(relation_name);
+                contact_repulsion_factor.add(
+                    &main_methods.template addInteractionDynamics<solid_dynamics::RepulsionFactor>(
+                        contact_relation));
+                contact_repulsion_force.add(
+                    &main_methods.template addInteractionDynamicsWithUpdate<
+                        solid_dynamics::RepulsionForceCK, Wall>(
+                        contact_relation, continuum_solver_parameters.contact_numerical_damping_));
             }
         }
     }

--- a/sphinxsim/sph_simulation/dynamics_builder/continuum_dynamics/continuum_interaction_builder.hpp
+++ b/sphinxsim/sph_simulation/dynamics_builder/continuum_dynamics/continuum_interaction_builder.hpp
@@ -32,17 +32,14 @@ BaseDynamics<void> &ContinuumDynamicsBuilder::addAcousticStep1stHalfForOneBody(
             RiemannSolverType, NoKernelCorrectionCK>(inner_relation);
 
         auto &sph_system = sim.getSPHSystem();
-        if (config_manager.hasEntity<SPHBodiesConfig>("SolidBodiesConfig"))
+        auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
+        for (const auto &sb_tgt : solid_bodies_config)
         {
-            auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
-            for (const auto &sb_tgt : solid_bodies_config)
-            {
-                std::string relation_name = body_name + sb_tgt->name_;
-                auto &contact_relation = sph_system.getRelationByName<
-                    Contact<Relation<RealBody, SolidBody>>>(relation_name);
-                complex_dynamics.template addPostContactInteraction<
-                    Wall, RiemannSolverType, NoKernelCorrectionCK>(contact_relation);
-            }
+            std::string relation_name = body_name + sb_tgt->name_;
+            auto &contact_relation = sph_system.getRelationByName<
+                Contact<Relation<RealBody, SolidBody>>>(relation_name);
+            complex_dynamics.template addPostContactInteraction<
+                Wall, RiemannSolverType, NoKernelCorrectionCK>(contact_relation);
         }
         return complex_dynamics;
     }
@@ -77,17 +74,14 @@ BaseDynamics<void> &ContinuumDynamicsBuilder::addAcousticStep2ndHalfForOneBody(
             inner_relation, continuum_solver_parameters.plastic_riemann_dissipation_factor_);
 
         auto &sph_system = sim.getSPHSystem();
-        if (config_manager.hasEntity<SPHBodiesConfig>("SolidBodiesConfig"))
+        auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
+        for (const auto &sb_tgt : solid_bodies_config)
         {
-            auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
-            for (const auto &sb_tgt : solid_bodies_config)
-            {
-                std::string relation_name = body_name + sb_tgt->name_;
-                auto &contact_relation = sph_system.getRelationByName<
-                    Contact<Relation<RealBody, SolidBody>>>(relation_name);
-                complex_dynamics.template addPostContactInteraction<
-                    Wall, RiemannSolverType, NoKernelCorrectionCK>(contact_relation);
-            }
+            std::string relation_name = body_name + sb_tgt->name_;
+            auto &contact_relation = sph_system.getRelationByName<
+                Contact<Relation<RealBody, SolidBody>>>(relation_name);
+            complex_dynamics.template addPostContactInteraction<
+                Wall, RiemannSolverType, NoKernelCorrectionCK>(contact_relation);
         }
         return complex_dynamics;
     }

--- a/sphinxsim/sph_simulation/dynamics_builder/fluid_dynamics/fluid_dynamics_builder.hpp
+++ b/sphinxsim/sph_simulation/dynamics_builder/fluid_dynamics/fluid_dynamics_builder.hpp
@@ -158,17 +158,14 @@ void FluidDynamicsBuilder::addAcousticHalfStepWithSolidBodies(
 {
     auto &sph_system = sim.getSPHSystem();
     auto &config_manager = sim.getConfigManager();
-    if (config_manager.hasEntity<SPHBodiesConfig>("SolidBodiesConfig"))
+    auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
+    for (const auto &sb_tgt : solid_bodies_config)
     {
-        auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
-        for (const auto &sb_tgt : solid_bodies_config)
-        {
-            std::string relation_name = body_name + sb_tgt->name_;
-            auto &contact_relation = sph_system.getRelationByName<
-                Contact<Relation<FluidBody, SolidBody>>>(relation_name);
-            complex_dynamics.template addPostContactInteraction<
-                Wall, RiemannSolverType, KernelCorrectionType>(contact_relation);
-        }
+        std::string relation_name = body_name + sb_tgt->name_;
+        auto &contact_relation = sph_system.getRelationByName<
+            Contact<Relation<FluidBody, SolidBody>>>(relation_name);
+        complex_dynamics.template addPostContactInteraction<
+            Wall, RiemannSolverType, KernelCorrectionType>(contact_relation);
     }
 }
 //=================================================================================================//

--- a/sphinxsim/sph_simulation/simulation_builder/base_simulation_builder.cpp
+++ b/sphinxsim/sph_simulation/simulation_builder/base_simulation_builder.cpp
@@ -31,12 +31,18 @@ SimulationBuilder::SimulationBuilder() : material_builder_ptr_(std::make_unique<
 //=================================================================================================//
 SimulationBuilder ::~SimulationBuilder() = default;
 //=================================================================================================//
+void SimulationBuilder::initializeAllBodyConfigs(EntityManager &config_manager)
+{
+    config_manager.emplaceEntity<SPHBodiesConfig>("FluidBodiesConfig");
+    config_manager.emplaceEntity<SPHBodiesConfig>("ContinuumBodiesConfig");
+    config_manager.emplaceEntity<SPHBodiesConfig>("SolidBodiesConfig");
+}
+//=================================================================================================//
 void SimulationBuilder::buildFluidBodies(
     SPHSystem &sph_system, EntityManager &config_manager, const json &config)
 {
     auto &scaling_config = config_manager.getEntity<ScalingConfig>("ScalingConfig");
-    SPHBodiesConfig &fluid_bodies_config =
-        *config_manager.emplaceEntity<SPHBodiesConfig>("FluidBodiesConfig");
+    auto &fluid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("FluidBodiesConfig");
 
     for (const auto &fb : config)
     {
@@ -64,8 +70,7 @@ void SimulationBuilder::buildFluidBodies(
 void SimulationBuilder::buildContinuumBodies(
     SPHSystem &sph_system, EntityManager &config_manager, const json &config)
 {
-    SPHBodiesConfig &continuum_bodies_config =
-        *config_manager.emplaceEntity<SPHBodiesConfig>("ContinuumBodiesConfig");
+    auto &continuum_bodies_config = config_manager.getEntity<SPHBodiesConfig>("ContinuumBodiesConfig");
 
     for (const auto &cb : config)
     {
@@ -104,8 +109,7 @@ void SPHBodyConfig::setHasDynamics()
 void SimulationBuilder::buildSolidBodies(
     SPHSystem &sph_system, EntityManager &config_manager, const json &config)
 {
-    SPHBodiesConfig &solid_bodies_config =
-        *config_manager.emplaceEntity<SPHBodiesConfig>("SolidBodiesConfig");
+    auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
 
     for (const auto &sb : config)
     {
@@ -237,26 +241,20 @@ void SimulationBuilder::buildExternalForceIfPresent(
     auto &scaling_config = config_manager.getEntity<ScalingConfig>("ScalingConfig");
     Vecd gravity_vector = scaling_config.jsonToVecd(config_gravity, "Acceleration");
 
-    if (config_manager.hasEntity<SPHBodiesConfig>("FluidBodiesConfig"))
+    auto &fluid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("FluidBodiesConfig");
+    for (const auto &fb : fluid_bodies_config)
     {
-        auto &fluid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("FluidBodiesConfig");
-        for (const auto &fb : fluid_bodies_config)
-        {
-            auto &fluid_body = sph_system.getBodyByName<FluidBody>(fb->name_);
-            gravity_force.add(&main_methods.template addStateDynamics<GravityForceCK<Gravity>>(
-                fluid_body, Gravity(gravity_vector)));
-        }
+        auto &fluid_body = sph_system.getBodyByName<FluidBody>(fb->name_);
+        gravity_force.add(&main_methods.template addStateDynamics<GravityForceCK<Gravity>>(
+            fluid_body, Gravity(gravity_vector)));
     }
 
-    if (config_manager.hasEntity<SPHBodiesConfig>("ContinuumBodiesConfig"))
+    auto &continuum_bodies_config = config_manager.getEntity<SPHBodiesConfig>("ContinuumBodiesConfig");
+    for (const auto &cb : continuum_bodies_config)
     {
-        auto &continuum_bodies_config = config_manager.getEntity<SPHBodiesConfig>("ContinuumBodiesConfig");
-        for (const auto &cb : continuum_bodies_config)
-        {
-            auto &continuum_body = sph_system.getBodyByName<RealBody>(cb->name_);
-            gravity_force.add(&main_methods.template addStateDynamics<GravityForceCK<Gravity>>(
-                continuum_body, Gravity(gravity_vector)));
-        }
+        auto &continuum_body = sph_system.getBodyByName<RealBody>(cb->name_);
+        gravity_force.add(&main_methods.template addStateDynamics<GravityForceCK<Gravity>>(
+            continuum_body, Gravity(gravity_vector)));
     }
 
     if (config_gravity.contains("enabled_solid_bodies"))

--- a/sphinxsim/sph_simulation/simulation_builder/base_simulation_builder.h
+++ b/sphinxsim/sph_simulation/simulation_builder/base_simulation_builder.h
@@ -149,6 +149,7 @@ class SimulationBuilder
     virtual void parseSolverParameters(EntityManager &config_manager, const json &config);
     static void parseScheduledEvents(SPHSimulation &sim, const json &config, bool &on_flag);
     static RestartConfig parseRestartConfig(const json &config);
+    static void initializeAllBodyConfigs(EntityManager &config_manager);
     static int parseLoglevel(const json &config);
 
   protected:

--- a/sphinxsim/sph_simulation/simulation_builder/fluid_simulation/fluid_simulation_builder.cpp
+++ b/sphinxsim/sph_simulation/simulation_builder/fluid_simulation/fluid_simulation_builder.cpp
@@ -7,8 +7,8 @@
 #include "composite_solid.h"
 #include "force_on_structure.h"
 #include "structure_surface_motion.h"
-#include "traveling_wave_active_strain.h"
 #include "thermal_dynamics_builder.hpp"
+#include "traveling_wave_active_strain.h"
 namespace SPH
 {
 using namespace fluid_dynamics;
@@ -176,7 +176,7 @@ void FluidSimulationBuilder::buildSimulation(SPHSimulation &sim, const json &con
     buildExternalForceIfPresent(sim, main_methods, config);
     FluidDynamicsBuilder::buildTransportVelocityFormulationIfNotFreeSurface(sim, main_methods);
     FluidDynamicsBuilder::buildViscousForceIfPresent(sim, main_methods);
-    if (config_manager.hasEntity<SPHBodiesConfig>("SolidBodiesConfig"))
+    if (!config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig").empty())
     {
         auto &fluid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("FluidBodiesConfig");
         auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");

--- a/sphinxsim/sph_simulation/simulation_builder/particle_configuration_builder.cpp
+++ b/sphinxsim/sph_simulation/simulation_builder/particle_configuration_builder.cpp
@@ -20,38 +20,29 @@ void SimulationBuilder::buildCellLinkedListDynamics(
     auto &config_manager = sim.getConfigManager();
     auto &update_cell_linked_list = main_methods.addParticleDynamicsGroup();
 
-    if (config_manager.hasEntity<SPHBodiesConfig>("FluidBodiesConfig"))
+    auto &fluid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("FluidBodiesConfig");
+    for (const auto &fb : fluid_bodies_config)
     {
-        auto &fluid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("FluidBodiesConfig");
-        for (const auto &fb : fluid_bodies_config)
-        {
-            auto &fluid_body = sph_system.getBodyByName<FluidBody>(fb->name_);
-            update_cell_linked_list.add(&main_methods.addCellLinkedListDynamics(fluid_body));
-        }
+        auto &fluid_body = sph_system.getBodyByName<FluidBody>(fb->name_);
+        update_cell_linked_list.add(&main_methods.addCellLinkedListDynamics(fluid_body));
     }
 
-    if (config_manager.hasEntity<SPHBodiesConfig>("ContinuumBodiesConfig"))
+    auto &continuum_bodies_config = config_manager.getEntity<SPHBodiesConfig>("ContinuumBodiesConfig");
+    for (const auto &cb : continuum_bodies_config)
     {
-        auto &continuum_bodies_config = config_manager.getEntity<SPHBodiesConfig>("ContinuumBodiesConfig");
-        for (const auto &cb : continuum_bodies_config)
-        {
-            auto &continuum_body = sph_system.getBodyByName<RealBody>(cb->name_);
-            update_cell_linked_list.add(&main_methods.addCellLinkedListDynamics(continuum_body));
-        }
+        auto &continuum_body = sph_system.getBodyByName<RealBody>(cb->name_);
+        update_cell_linked_list.add(&main_methods.addCellLinkedListDynamics(continuum_body));
     }
 
     auto &static_cell_linked_list = main_methods.addParticleDynamicsGroup();
-    if (config_manager.hasEntity<SPHBodiesConfig>("SolidBodiesConfig"))
+    auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
+    for (const auto &sb : solid_bodies_config)
     {
-        auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
-        for (const auto &sb : solid_bodies_config)
-        {
 
-            auto &solid_body = sph_system.getBodyByName<SolidBody>(sb->name_);
-            sb->is_moving_
-                ? update_cell_linked_list.add(&main_methods.addCellLinkedListDynamics(solid_body))
-                : static_cell_linked_list.add(&main_methods.addCellLinkedListDynamics(solid_body));
-        }
+        auto &solid_body = sph_system.getBodyByName<SolidBody>(sb->name_);
+        sb->is_moving_
+            ? update_cell_linked_list.add(&main_methods.addCellLinkedListDynamics(solid_body))
+            : static_cell_linked_list.add(&main_methods.addCellLinkedListDynamics(solid_body));
     }
 
     auto &initialization_pipeline = sim.getInitializationPipeline();
@@ -69,13 +60,13 @@ void SimulationBuilder::buildFluidRelationDynamics(
     SPHSimulation &sim, MainMethods &main_methods, const json &config)
 {
     auto &config_manager = sim.getConfigManager();
-    if (!config_manager.hasEntity<SPHBodiesConfig>("FluidBodiesConfig"))
+    auto &fluid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("FluidBodiesConfig");
+    if (fluid_bodies_config.empty())
         return;
 
     auto &sph_system = sim.getSPHSystem();
     auto &update_all_fluid_relations = main_methods.addParticleDynamicsGroup();
 
-    auto &fluid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("FluidBodiesConfig");
     for (const auto &fb_src : fluid_bodies_config)
     {
         auto &fluid_body = sph_system.getBodyByName<FluidBody>(fb_src->name_);
@@ -93,28 +84,23 @@ void SimulationBuilder::buildFluidRelationDynamics(
             }
         }
 
-        if (config_manager.hasEntity<SPHBodiesConfig>("ContinuumBodiesConfig"))
+        auto &continuum_bodies_config = config_manager.getEntity<SPHBodiesConfig>("ContinuumBodiesConfig");
+        for (const auto &cb_tgt : continuum_bodies_config)
         {
-            auto &continuum_bodies_config = config_manager.getEntity<SPHBodiesConfig>("ContinuumBodiesConfig");
-            for (const auto &cb_tgt : continuum_bodies_config)
-            {
-                auto &continuum_body_target = sph_system.getBodyByName<RealBody>(cb_tgt->name_);
-                auto &fluid_contact = sph_system.addContactRelation(fluid_body, continuum_body_target);
-                update_fluid_relation.add(&main_methods.addRelationDynamics(fluid_contact));
-            }
+            auto &continuum_body_target = sph_system.getBodyByName<RealBody>(cb_tgt->name_);
+            auto &fluid_contact = sph_system.addContactRelation(fluid_body, continuum_body_target);
+            update_fluid_relation.add(&main_methods.addRelationDynamics(fluid_contact));
         }
 
-        if (config_manager.hasEntity<SPHBodiesConfig>("SolidBodiesConfig"))
+        auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
+        for (const auto &sb_tgt : solid_bodies_config)
         {
-            auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
-            for (const auto &sb_tgt : solid_bodies_config)
-            {
-                auto &solid_body_target = sph_system.getBodyByName<SolidBody>(sb_tgt->name_);
-                auto &fluid_contact = sph_system.addContactRelation(fluid_body, solid_body_target);
-                update_fluid_relation.add(&main_methods.addRelationDynamics(fluid_contact));
-            }
-            update_all_fluid_relations.add(&update_fluid_relation);
+            auto &solid_body_target = sph_system.getBodyByName<SolidBody>(sb_tgt->name_);
+            auto &fluid_contact = sph_system.addContactRelation(fluid_body, solid_body_target);
+            update_fluid_relation.add(&main_methods.addRelationDynamics(fluid_contact));
         }
+
+        update_all_fluid_relations.add(&update_fluid_relation);
     }
 
     addUpdateConfigurationDynamicsToPipeline(sim, config_manager, update_all_fluid_relations);
@@ -124,13 +110,13 @@ void SimulationBuilder::buildContinuumRelationDynamics(
     SPHSimulation &sim, MainMethods &main_methods, const json &config)
 {
     auto &config_manager = sim.getConfigManager();
-    if (!config_manager.hasEntity<SPHBodiesConfig>("ContinuumBodiesConfig"))
+    auto &continuum_bodies_config = config_manager.getEntity<SPHBodiesConfig>("ContinuumBodiesConfig");
+    if (continuum_bodies_config.empty())
         return;
 
     auto &sph_system = sim.getSPHSystem();
     auto &update_all_continuum_relations = main_methods.addParticleDynamicsGroup();
 
-    auto &continuum_bodies_config = config_manager.getEntity<SPHBodiesConfig>("ContinuumBodiesConfig");
     for (const auto &cb_src : continuum_bodies_config)
     {
         auto &continuum_body = sph_system.getBodyByName<RealBody>(cb_src->name_);
@@ -147,28 +133,24 @@ void SimulationBuilder::buildContinuumRelationDynamics(
                 update_continuum_relation.add(&main_methods.addRelationDynamics(continuum_contact));
             }
         }
-        if (config_manager.hasEntity<SPHBodiesConfig>("FluidBodiesConfig"))
+
+        auto &fluid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("FluidBodiesConfig");
+        for (const auto &fb_tgt : fluid_bodies_config)
         {
-            auto &fluid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("FluidBodiesConfig");
-            for (const auto &fb_tgt : fluid_bodies_config)
-            {
-                auto &fluid_body_target = sph_system.getBodyByName<FluidBody>(fb_tgt->name_);
-                auto &continuum_contact = sph_system.addContactRelation(continuum_body, fluid_body_target);
-                update_continuum_relation.add(&main_methods.addRelationDynamics(continuum_contact));
-            }
+            auto &fluid_body_target = sph_system.getBodyByName<FluidBody>(fb_tgt->name_);
+            auto &continuum_contact = sph_system.addContactRelation(continuum_body, fluid_body_target);
+            update_continuum_relation.add(&main_methods.addRelationDynamics(continuum_contact));
         }
 
-        if (config_manager.hasEntity<SPHBodiesConfig>("SolidBodiesConfig"))
+        auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
+        for (const auto &sb_tgt : solid_bodies_config)
         {
-            auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
-            for (const auto &sb_tgt : solid_bodies_config)
-            {
-                auto &solid_body_target = sph_system.getBodyByName<SolidBody>(sb_tgt->name_);
-                auto &continuum_contact = sph_system.addContactRelation(continuum_body, solid_body_target);
-                update_continuum_relation.add(&main_methods.addRelationDynamics(continuum_contact));
-            }
-            update_all_continuum_relations.add(&update_continuum_relation);
+            auto &solid_body_target = sph_system.getBodyByName<SolidBody>(sb_tgt->name_);
+            auto &continuum_contact = sph_system.addContactRelation(continuum_body, solid_body_target);
+            update_continuum_relation.add(&main_methods.addRelationDynamics(continuum_contact));
         }
+
+        update_all_continuum_relations.add(&update_continuum_relation);
     }
 
     addUpdateConfigurationDynamicsToPipeline(sim, config_manager, update_all_continuum_relations);
@@ -178,14 +160,14 @@ void SimulationBuilder::buildSolidRelationDynamics(
     SPHSimulation &sim, MainMethods &main_methods, const json &config)
 {
     auto &config_manager = sim.getConfigManager();
-    if (!config_manager.hasEntity<SPHBodiesConfig>("SolidBodiesConfig"))
+    auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
+    if (solid_bodies_config.empty())
         return;
 
     auto &sph_system = sim.getSPHSystem();
     auto &update_all_contact_relations = main_methods.addParticleDynamicsGroup();
     auto &total_lagrangian_relations = main_methods.addParticleDynamicsGroup();
 
-    auto &solid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("SolidBodiesConfig");
     for (const auto &sb_src : solid_bodies_config)
     {
         auto &solid_body = sph_system.getBodyByName<SolidBody>(sb_src->name_);
@@ -217,26 +199,22 @@ void SimulationBuilder::buildSolidRelationDynamics(
                 }
             }
 
-            if (config_manager.hasEntity<SPHBodiesConfig>("FluidBodiesConfig"))
+            auto &fluid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("FluidBodiesConfig");
+            for (const auto &fb_tgt : fluid_bodies_config)
             {
-                auto &fluid_bodies_config = config_manager.getEntity<SPHBodiesConfig>("FluidBodiesConfig");
-                for (const auto &fb_tgt : fluid_bodies_config)
-                {
-                    auto &fluid_body_target = sph_system.getBodyByName<FluidBody>(fb_tgt->name_);
-                    auto &solid_contact = sph_system.addContactRelation(solid_body, fluid_body_target);
-                    update_contact_relation.add(&main_methods.addRelationDynamics(solid_contact));
-                }
+                auto &fluid_body_target = sph_system.getBodyByName<FluidBody>(fb_tgt->name_);
+                auto &solid_contact = sph_system.addContactRelation(solid_body, fluid_body_target);
+                update_contact_relation.add(&main_methods.addRelationDynamics(solid_contact));
             }
-            if (config_manager.hasEntity<SPHBodiesConfig>("ContinuumBodiesConfig"))
+
+            auto &continuum_bodies_config = config_manager.getEntity<SPHBodiesConfig>("ContinuumBodiesConfig");
+            for (const auto &cb_tgt : continuum_bodies_config)
             {
-                auto &continuum_bodies_config = config_manager.getEntity<SPHBodiesConfig>("ContinuumBodiesConfig");
-                for (const auto &cb_tgt : continuum_bodies_config)
-                {
-                    auto &continuum_body_target = sph_system.getBodyByName<RealBody>(cb_tgt->name_);
-                    auto &solid_contact = sph_system.addContactRelation(solid_body, continuum_body_target);
-                    update_contact_relation.add(&main_methods.addRelationDynamics(solid_contact));
-                }
+                auto &continuum_body_target = sph_system.getBodyByName<RealBody>(cb_tgt->name_);
+                auto &solid_contact = sph_system.addContactRelation(solid_body, continuum_body_target);
+                update_contact_relation.add(&main_methods.addRelationDynamics(solid_contact));
             }
+
             update_all_contact_relations.add(&update_contact_relation);
         }
     }

--- a/sphinxsim/sph_simulation/sph_simulation.cpp
+++ b/sphinxsim/sph_simulation/sph_simulation.cpp
@@ -117,6 +117,7 @@ void SPHSimulation::buildSimulation()
     }
 
     json config = loadConfig();
+    SimulationBuilder::initializeAllBodyConfigs(config_manager_);
     if (config.contains("simulation_type"))
     {
         std::string simulation_type = config.at("simulation_type").get<std::string>();


### PR DESCRIPTION
This pull request refactors how body configuration entities are managed and accessed throughout the simulation codebase. The main change is the removal of redundant existence checks (`hasEntity`) before accessing body configuration entities, relying instead on their guaranteed initialization at the start of the simulation. This simplifies the logic and improves code clarity. Additionally, a new static method ensures all required body configs are initialized up front.

**Initialization and entity management improvements:**

* Added `SimulationBuilder::initializeAllBodyConfigs` to pre-initialize all `SPHBodiesConfig` entities (`FluidBodiesConfig`, `ContinuumBodiesConfig`, `SolidBodiesConfig`) in the `EntityManager`, and called this during simulation setup to guarantee their existence. [[1]](diffhunk://#diff-dc1dab3fc86e0e89fc0b1874dc0bc9b4048999010e1a4d4b9a557bdcb3f22c1eR34-R45) [[2]](diffhunk://#diff-51f723eac8c19d64123ebfc316e649e98b9ee1679f5e3b915b415b9448cc0872R152) [[3]](diffhunk://#diff-2b259acf3469cab5aa66541505042cb74eff0f524194db08f34e4e271e495448R120)

**Refactoring to remove redundant checks:**

* Removed `hasEntity` checks before accessing body configs in multiple locations (e.g., `buildFluidBodies`, `buildContinuumBodies`, `buildSolidBodies`, `buildExternalForceIfPresent`, `buildCellLinkedListDynamics`, and relation dynamics builders), and replaced them with direct access since entities are now always present. [[1]](diffhunk://#diff-dc1dab3fc86e0e89fc0b1874dc0bc9b4048999010e1a4d4b9a557bdcb3f22c1eL67-R73) [[2]](diffhunk://#diff-dc1dab3fc86e0e89fc0b1874dc0bc9b4048999010e1a4d4b9a557bdcb3f22c1eL107-R112) [[3]](diffhunk://#diff-dc1dab3fc86e0e89fc0b1874dc0bc9b4048999010e1a4d4b9a557bdcb3f22c1eL240-L260) [[4]](diffhunk://#diff-4f0835f0cc6065ae14a8444149a46431236e43e47abf523f37a6e5923de5a827L23-L45) [[5]](diffhunk://#diff-4f0835f0cc6065ae14a8444149a46431236e43e47abf523f37a6e5923de5a827L55) [[6]](diffhunk://#diff-4f0835f0cc6065ae14a8444149a46431236e43e47abf523f37a6e5923de5a827L72-L78) [[7]](diffhunk://#diff-4f0835f0cc6065ae14a8444149a46431236e43e47abf523f37a6e5923de5a827L96-L118) [[8]](diffhunk://#diff-4f0835f0cc6065ae14a8444149a46431236e43e47abf523f37a6e5923de5a827L127-L133) [[9]](diffhunk://#diff-4f0835f0cc6065ae14a8444149a46431236e43e47abf523f37a6e5923de5a827L150-L172) [[10]](diffhunk://#diff-4f0835f0cc6065ae14a8444149a46431236e43e47abf523f37a6e5923de5a827L181-L188) [[11]](diffhunk://#diff-4f0835f0cc6065ae14a8444149a46431236e43e47abf523f37a6e5923de5a827L220-R217) [[12]](diffhunk://#diff-76ca86a1ebf1712a55618f8264723fe9be45a7a947801c2debb219b4e6a7d253L192-L193) [[13]](diffhunk://#diff-76ca86a1ebf1712a55618f8264723fe9be45a7a947801c2debb219b4e6a7d253L210) [[14]](diffhunk://#diff-66c9aee1d39d3e433a665839d806877858d4ef581cd8f2de907fdd91f05c1e12L35-L36) [[15]](diffhunk://#diff-66c9aee1d39d3e433a665839d806877858d4ef581cd8f2de907fdd91f05c1e12L46) [[16]](diffhunk://#diff-66c9aee1d39d3e433a665839d806877858d4ef581cd8f2de907fdd91f05c1e12L80-L81) [[17]](diffhunk://#diff-66c9aee1d39d3e433a665839d806877858d4ef581cd8f2de907fdd91f05c1e12L91) [[18]](diffhunk://#diff-a3e797af1beb362483cfd04831eda4b378e0f69f89d5ad4cf1dfa2c18d0ee05eL161-L162) [[19]](diffhunk://#diff-a3e797af1beb362483cfd04831eda4b378e0f69f89d5ad4cf1dfa2c18d0ee05eL173)

**Logic simplification and minor improvements:**

* Updated checks for presence of solid bodies in `FluidSimulationBuilder::buildSimulation` to use `.empty()` instead of `hasEntity`, aligning with the new initialization approach.
* Minor include order fix in `fluid_simulation_builder.cpp` for consistency.

These changes collectively streamline the code, reduce the risk of runtime errors due to missing entities, and improve maintainability by centralizing entity initialization.