### PR TITLE
Xiangyu/revise python interface

### DIFF
--- a/.github/skills/visualization/SKILL.md
+++ b/.github/skills/visualization/SKILL.md
@@ -61,6 +61,12 @@ Design rule:
 - Keep rendering robust when PyVista or mesh assets are unavailable.
 - Support screenshot output via `screenshot_path` parameter on `preview()`.
 - Rebuild geometry on each preview run and refresh the shape-bounds cache from the builder.
+- For shell `preview --with-particles`, transfer the generated `SPHSimulation`
+  and its temporary runtime config to `_ShellPreviewRuntime`. The runtime keeps
+  both alive only until the immediate `continue-to-run` command invokes
+  `buildSimulation()`, `initializeSimulation()`, and `run()`.
+- Any other shell command must release the retained simulation and delete its
+  temporary runtime config.
 
 ### Annotation functions
 Keep annotation formatting centralized in `annotations.py`:
@@ -126,6 +132,14 @@ Use `tests/test_visualization.py`.
 - Respect schema requirements:
   - region oriented box requires `half_size` and `transform`.
   - simbody constraints require `config.restart`.
+
+5. Shell particle-preview continuation
+- Test that `continue-to-run` calls `buildSimulation()`,
+  `initializeSimulation()`, and `run()` on the retained simulation, in order.
+- Test that the retained temporary runtime config remains available through the
+  continued run and is deleted afterward.
+- Test that another shell command releases the retained simulation instead of
+  allowing it to survive into a later workflow.
 
 ## Common failure patterns
 - Missing import in local `annotations` import block inside `_populate_plotter`.

--- a/.github/skills/visualization/SKILL.md
+++ b/.github/skills/visualization/SKILL.md
@@ -65,6 +65,11 @@ Design rule:
   and its temporary runtime config to `_ShellPreviewRuntime`. The runtime keeps
   both alive only until the immediate `continue-to-run` command invokes
   `buildSimulation()`, `initializeSimulation()`, and `run()`.
+- `continue-to-run` accepts `--refresh-interval SECONDS` with a default of
+  `10`. It runs the solver in a worker thread and, for a Qt-backed persistent
+  preview, uses a GUI-thread timer to replace particle actors from newer
+  completed body-state VTP snapshots. The interval is wall-clock time and must
+  be positive.
 - Any other shell command must release the retained simulation and delete its
   temporary runtime config.
 
@@ -140,6 +145,11 @@ Use `tests/test_visualization.py`.
   continued run and is deleted afterward.
 - Test that another shell command releases the retained simulation instead of
   allowing it to survive into a later workflow.
+- Test `--refresh-interval` parsing, including the default `10` seconds and
+  rejection of zero or negative values.
+- Mock the GUI timer and VTP reader when testing live refresh. Do not mutate
+  PyVista/VTK actors from the solver worker thread; timer callbacks own actor
+  updates on the Qt GUI thread.
 
 ## Common failure patterns
 - Missing import in local `annotations` import block inside `_populate_plotter`.

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -132,6 +132,7 @@ Inside the shell, you can use the following commands:
 | `preview` | Render an interactive geometry/BC preview of the loaded config |
 | `preview --with-particles` | Also run particle generation and overlay the latest generated particles per body |
 | `preview --screenshot FILE` | Save a screenshot to FILE instead of opening an interactive window |
+| `continue-to-run` | Build, initialize, and run the simulation retained by the most recent particle preview |
 | `run` | Build and execute the loaded config |
 | `help` | Show available commands |
 | `exit` | Quit the shell |
@@ -142,6 +143,7 @@ Notes:
 - In shell mode, slash-prefixed commands are also accepted, e.g. `/generate water dam break simulation config.json` or `/update simulate for 2 s`.
 - `validate` always reloads from disk, so external edits are picked up immediately.
 - In shell mode, `preview` keeps a persistent window and returns control to the prompt. Running `preview` again updates the same window.
+- `preview --with-particles` retains its generated-particle simulation for one immediate `continue-to-run` command. Any other command discards that retained simulation.
 - For responsive persistent preview, install `pyvistaqt` and a Qt backend (`PySide6` or `PyQt5`).
 - In the Qt-backed preview, edit settings in the searchable dark property tree on the right and press `Ctrl+S`; only then are changes validated, saved, and rendered. If `preview` would reset unapplied edits, it asks for confirmation first.
 - To switch configurations while the Preview window remains open, run `load OTHER.json` followed by `preview`; the property editor is rebound to the newly loaded file.

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -132,7 +132,7 @@ Inside the shell, you can use the following commands:
 | `preview` | Render an interactive geometry/BC preview of the loaded config |
 | `preview --with-particles` | Also run particle generation and overlay the latest generated particles per body |
 | `preview --screenshot FILE` | Save a screenshot to FILE instead of opening an interactive window |
-| `continue-to-run` | Build, initialize, and run the simulation retained by the most recent particle preview |
+| `continue-to-run [--refresh-interval SECONDS]` | Build, initialize, and run the simulation retained by the most recent particle preview; refresh displayed particles every 10 seconds by default |
 | `run` | Build and execute the loaded config |
 | `help` | Show available commands |
 | `exit` | Quit the shell |
@@ -144,6 +144,7 @@ Notes:
 - `validate` always reloads from disk, so external edits are picked up immediately.
 - In shell mode, `preview` keeps a persistent window and returns control to the prompt. Running `preview` again updates the same window.
 - `preview --with-particles` retains its generated-particle simulation for one immediate `continue-to-run` command. Any other command discards that retained simulation.
+- `continue-to-run --refresh-interval SECONDS` checks for newer body-state VTP files at the requested positive wall-clock interval. The default is `10` seconds. Live refresh requires the Qt-backed persistent preview (`pyvistaqt` with `PySide6` or `PyQt5`); the simulation still runs when that preview is unavailable, but its particles are not updated live.
 - For responsive persistent preview, install `pyvistaqt` and a Qt backend (`PySide6` or `PyQt5`).
 - In the Qt-backed preview, edit settings in the searchable dark property tree on the right and press `Ctrl+S`; only then are changes validated, saved, and rendered. If `preview` would reset unapplied edits, it asks for confirmation first.
 - To switch configurations while the Preview window remains open, run `load OTHER.json` followed by `preview`; the property editor is rebound to the newly loaded file.

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -155,9 +155,23 @@ sphinxsim> preview --with-particles
    Building C++ geometry; bounds cache fallback will be used if VTP meshes are unavailable.
    Particle generation overlay is enabled (--with-particles).
 ✅ Preview used C++ geometry (VTP meshes).
+
+sphinxsim> continue-to-run
+✅ Simulation built
+✅ Simulation initialized
+🚀 Running simulation...
+✅ Simulation completed successfully!
 ```
 
 `preview` requires a config to be loaded first (via `load` or `generate`).
+
+After `preview --with-particles`, the shell retains the generated-particle
+`SPHSimulation` instance and its temporary runtime config for one immediate
+`continue-to-run`. This continues the same instance through
+`buildSimulation()`, `initializeSimulation()`, and `run()`, without generating
+particles again. Any other shell command discards the retained instance and its
+temporary config; use `run` when a fresh simulation from the saved config is
+intended.
 
 ## Python API
 

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -156,10 +156,11 @@ sphinxsim> preview --with-particles
    Particle generation overlay is enabled (--with-particles).
 ✅ Preview used C++ geometry (VTP meshes).
 
-sphinxsim> continue-to-run
+sphinxsim> continue-to-run --refresh-interval 10
 ✅ Simulation built
 ✅ Simulation initialized
 🚀 Running simulation...
+ℹ️ Preview refreshes every 10 seconds while simulation runs.
 ✅ Simulation completed successfully!
 ```
 
@@ -172,6 +173,19 @@ After `preview --with-particles`, the shell retains the generated-particle
 particles again. Any other shell command discards the retained instance and its
 temporary config; use `run` when a fresh simulation from the saved config is
 intended.
+
+`continue-to-run` accepts an optional wall-clock refresh interval:
+
+```text
+sphinxsim> continue-to-run --refresh-interval 2.5
+```
+
+The default is `10` seconds and the value must be greater than zero. While the
+simulation runs, the persistent Qt preview checks the output folder at that
+interval and replaces each particle cloud when a newer complete body-state VTP
+snapshot is available. This uses `pyvistaqt` plus `PySide6` or `PyQt5`; without
+a Qt-backed persistent preview, the simulation still continues but the window
+cannot refresh its particles live.
 
 ## Python API
 

--- a/sphinxsim/bindings/sphinxsys_python.cpp
+++ b/sphinxsim/bindings/sphinxsys_python.cpp
@@ -48,7 +48,7 @@ PYBIND11_MODULE(MODULE_NAME, m)
              "Build simulation (relations, dynamics, etc.) from JSON configuration")
         .def("initializeSimulation", &SPHSimulation::initializeSimulation,
              "Initialize executable simulation state after build and before run")
-        .def("run", &SPHSimulation::run,
+        .def("run", &SPHSimulation::run, py::call_guard<py::gil_scoped_release>(),
              "Run simulation until solver_parameters.end_time (requires initializeSimulation first)")
         .def("stepTo", &SPHSimulation::stepTo, py::arg("target_time"),
              "Advance simulation to target physical time")

--- a/sphinxsim/cli.py
+++ b/sphinxsim/cli.py
@@ -28,6 +28,7 @@ import tempfile
 import time
 import warnings
 from pathlib import Path
+from threading import Thread
 from typing import Any, Tuple
 
 # Set up sys.path FIRST, before any sphinxsim imports
@@ -660,10 +661,17 @@ class _ShellPreviewRuntime:
         self._json_editor: Any | None = None
         self._pending_simulation: Any | None = None
         self._pending_runtime_config_path: Path | None = None
+        self._live_run_thread: Thread | None = None
+        self._live_refresh_timer: Any | None = None
+        self._live_output_dir: Path | None = None
+        self._live_particle_body_names: set[str] = set()
+        self._live_particle_colours: dict[str, Any] = {}
+        self._live_particle_versions: dict[str, int] = {}
 
     def _reset_preview_state(self) -> None:
         """Forget all state associated with a closed preview window."""
         self._remove_hover_observer()
+        self._stop_live_refresh()
         self.discard_pending_simulation()
         self.plotter = None
         self._json_editor = None
@@ -707,8 +715,90 @@ class _ShellPreviewRuntime:
             except OSError:
                 pass
 
-    def continue_to_run(self) -> int:
-        """Finish and run the simulation retained by particle preview."""
+    def _stop_live_refresh(self) -> None:
+        timer = self._live_refresh_timer
+        self._live_refresh_timer = None
+        if timer is not None:
+            try:
+                timer.stop()
+            except Exception:
+                pass
+        self._live_output_dir = None
+        self._live_particle_body_names = set()
+        self._live_particle_colours = {}
+        self._live_particle_versions = {}
+
+    def _refresh_live_particles(self) -> None:
+        """Replace particle actors with the newest completed runtime snapshots."""
+        if self.plotter is None or self._live_output_dir is None:
+            return
+
+        from sphinxsim.visualization.preview import _PARTICLE_POINT_SIZE
+
+        try:
+            import pyvista as pv
+        except ImportError:
+            return
+
+        for vtp_path in self._live_output_dir.glob("*.vtp"):
+            for body_name in self._live_particle_body_names:
+                prefix = f"{body_name}_"
+                if not vtp_path.stem.startswith(prefix):
+                    continue
+                suffix = vtp_path.stem[len(prefix):]
+                if suffix.startswith("ite_"):
+                    suffix = suffix[len("ite_"):]
+                try:
+                    sequence = float(suffix)
+                except ValueError:
+                    break
+                previous_sequence = self._live_particle_versions.get(body_name, float("-inf"))
+                if sequence <= previous_sequence:
+                    break
+                try:
+                    mesh = pv.read(str(vtp_path))
+                except Exception:
+                    break
+                self.plotter.add_mesh(
+                    mesh,
+                    name=f"particle-preview-{body_name}",
+                    color=self._live_particle_colours.get(body_name),
+                    opacity=0.95,
+                    style="points",
+                    point_size=_PARTICLE_POINT_SIZE,
+                    label=f"Particles: {body_name}",
+                )
+                self._live_particle_versions[body_name] = sequence
+                break
+
+        thread = self._live_run_thread
+        if thread is not None and not thread.is_alive():
+            self._stop_live_refresh()
+            self._live_run_thread = None
+
+    def _start_live_refresh(self, refresh_interval: float) -> None:
+        timer = self._live_refresh_timer
+        if timer is not None:
+            try:
+                timer.stop()
+            except Exception:
+                pass
+        self._live_refresh_timer = None
+        self._live_particle_versions = {}
+        if not self._using_background_plotter or self.plotter is None:
+            return
+        try:
+            from qtpy import QtCore
+        except ImportError:
+            return
+        timer = QtCore.QTimer()
+        timer.setInterval(max(1, round(refresh_interval * 1000)))
+        timer.timeout.connect(self._refresh_live_particles)
+        timer.start()
+        self._live_refresh_timer = timer
+
+    def continue_to_run(self, refresh_interval: float = 10.0) -> int:
+        """Run the retained simulation and refresh its particle preview periodically."""
         simulation = self._pending_simulation
         runtime_config_path = self._pending_runtime_config_path
         self._pending_simulation = None
@@ -731,19 +821,36 @@ class _ShellPreviewRuntime:
             simulation.initializeSimulation()
             print("✅ Simulation initialized")
             print("\n🚀 Running simulation...")
-            simulation.run()
-            print("✅ Simulation completed successfully!")
+            self._start_live_refresh(refresh_interval)
+
+            def run_simulation() -> None:
+                try:
+                    simulation.run()
+                    print("✅ Simulation completed successfully!")
+                except Exception as exc:
+                    print(f"❌ Continued run failed: {exc}", file=sys.stderr)
+                finally:
+                    if runtime_config_path is not None:
+                        try:
+                            runtime_config_path.unlink(missing_ok=True)
+                        except OSError:
+                            pass
+
+            self._live_run_thread = Thread(target=run_simulation, daemon=True)
+            self._live_run_thread.start()
+            print(f"ℹ️ Preview refreshes every {refresh_interval:g} seconds while simulation runs.")
             return 0
         except Exception as exc:
             print(f"❌ Continued run failed: {exc}", file=sys.stderr)
             return 1
         finally:
-            del simulation
-            if runtime_config_path is not None:
-                try:
-                    runtime_config_path.unlink(missing_ok=True)
-                except OSError:
-                    pass
+            if self._live_run_thread is None:
+                del simulation
+                if runtime_config_path is not None:
+                    try:
+                        runtime_config_path.unlink(missing_ok=True)
+                    except OSError:
+                        pass
 
     def _install_json_editor(
         self,
@@ -1777,10 +1884,20 @@ class _ShellPreviewRuntime:
             if with_particles:
                 pending_simulation = visualizer.take_particle_simulation()
                 if pending_simulation is not None:
+                    from sphinxsim.visualization.preview import _body_colour
+
                     (
                         self._pending_simulation,
                         self._pending_runtime_config_path,
                     ) = pending_simulation
+                    self._live_output_dir = vtp_dir or (
+                        PROJECT_ROOT / ".build-temp" / "test_simulation" / "output"
+                    )
+                    self._live_particle_body_names = visualizer._particle_generation_body_names()
+                    self._live_particle_colours = {
+                        body_name: _body_colour(body_name, config)
+                        for body_name in self._live_particle_body_names
+                    }
             if configure_layout is not None:
                 configure_layout(self.plotter)
             visualizer._configure_default_view(self.plotter, ndim)
@@ -1828,7 +1945,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
             "Commands: load FILE, generate DESCRIPTION FILE, "
             "update [--patch-mode] [--dry-run] [--strict true|false] INSTRUCTION, "
                 "validate, run, preview [--with-particles] [--screenshot FILE], "
-                "continue-to-run, explore QUESTION, exit"
+                    "continue-to-run [--refresh-interval SECONDS], explore QUESTION, exit"
     )
     print("Note: relative paths are resolved from the current directory first, then .build-temp/.")
 
@@ -1867,7 +1984,8 @@ def cmd_shell(args: argparse.Namespace) -> int:
             print("  preview                         - Render geometry/BC preview (requires pyvista)")
             print("  preview --with-particles        - Run particle generation and overlay particles")
             print("  preview --screenshot FILE        - Save a screenshot to FILE instead of interactive window")
-            print("  continue-to-run                 - Finish and run the retained particle preview simulation")
+            print("  continue-to-run [--refresh-interval SECONDS]")
+            print("                                 - Finish and run the retained particle preview simulation")
             print("  run                             - Run simulation from loaded config")
             print("  exit                            - Exit shell")
             continue
@@ -2058,7 +2176,22 @@ def cmd_shell(args: argparse.Namespace) -> int:
             continue
 
         if cmd == "continue-to-run":
-            _ = preview_runtime.continue_to_run()
+            refresh_interval = 10.0
+            if len(parts) == 3 and parts[1] == "--refresh-interval":
+                try:
+                    refresh_interval = float(parts[2])
+                except ValueError:
+                    refresh_interval = 0.0
+            elif len(parts) != 1:
+                print(
+                    "Usage: continue-to-run [--refresh-interval SECONDS]",
+                    file=sys.stderr,
+                )
+                continue
+            if refresh_interval <= 0.0:
+                print("Refresh interval must be greater than zero.", file=sys.stderr)
+                continue
+            _ = preview_runtime.continue_to_run(refresh_interval)
             continue
 
         if cmd == "run":

--- a/sphinxsim/cli.py
+++ b/sphinxsim/cli.py
@@ -666,7 +666,7 @@ class _ShellPreviewRuntime:
         self._live_output_dir: Path | None = None
         self._live_particle_body_names: set[str] = set()
         self._live_particle_colours: dict[str, Any] = {}
-        self._live_particle_versions: dict[str, int] = {}
+        self._live_particle_versions: dict[str, float] = {}
 
     def _reset_preview_state(self) -> None:
         """Forget all state associated with a closed preview window."""

--- a/sphinxsim/cli.py
+++ b/sphinxsim/cli.py
@@ -658,10 +658,13 @@ class _ShellPreviewRuntime:
         self._hover_interactor: Any | None = None
         self._hover_observer_tag: Any | None = None
         self._json_editor: Any | None = None
+        self._pending_simulation: Any | None = None
+        self._pending_runtime_config_path: Path | None = None
 
     def _reset_preview_state(self) -> None:
         """Forget all state associated with a closed preview window."""
         self._remove_hover_observer()
+        self.discard_pending_simulation()
         self.plotter = None
         self._json_editor = None
         self.last_signature = None
@@ -692,6 +695,55 @@ class _ShellPreviewRuntime:
             except Exception:
                 pass
         self._reset_preview_state()
+
+    def discard_pending_simulation(self) -> None:
+        """Release a simulation retained by ``preview --with-particles``."""
+        self._pending_simulation = None
+        runtime_config_path = self._pending_runtime_config_path
+        self._pending_runtime_config_path = None
+        if runtime_config_path is not None:
+            try:
+                runtime_config_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def continue_to_run(self) -> int:
+        """Finish and run the simulation retained by particle preview."""
+        simulation = self._pending_simulation
+        runtime_config_path = self._pending_runtime_config_path
+        self._pending_simulation = None
+        self._pending_runtime_config_path = None
+        if simulation is None:
+            if runtime_config_path is not None:
+                try:
+                    runtime_config_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            print(
+                "No particle-preview simulation is available. Run 'preview --with-particles' first.",
+                file=sys.stderr,
+            )
+            return 1
+
+        try:
+            simulation.buildSimulation()
+            print("✅ Simulation built")
+            simulation.initializeSimulation()
+            print("✅ Simulation initialized")
+            print("\n🚀 Running simulation...")
+            simulation.run()
+            print("✅ Simulation completed successfully!")
+            return 0
+        except Exception as exc:
+            print(f"❌ Continued run failed: {exc}", file=sys.stderr)
+            return 1
+        finally:
+            del simulation
+            if runtime_config_path is not None:
+                try:
+                    runtime_config_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
 
     def _install_json_editor(
         self,
@@ -1722,6 +1774,13 @@ class _ShellPreviewRuntime:
             if draw_sidebar is not None:
                 draw_sidebar(self.plotter)
             visualizer._populate_plotter(self.plotter, vtp_dir, latest_particle_vtps)
+            if with_particles:
+                pending_simulation = visualizer.take_particle_simulation()
+                if pending_simulation is not None:
+                    (
+                        self._pending_simulation,
+                        self._pending_runtime_config_path,
+                    ) = pending_simulation
             if configure_layout is not None:
                 configure_layout(self.plotter)
             visualizer._configure_default_view(self.plotter, ndim)
@@ -1730,7 +1789,7 @@ class _ShellPreviewRuntime:
 
             if vtp_dir:
                 mode_label = "VTP geometry"
-            elif visualizer._bounds_sim is not None:
+            elif visualizer.used_cpp_bounds:
                 mode_label = "C++ bounds fallback"
             else:
                 mode_label = "No C++ geometry"
@@ -1768,7 +1827,8 @@ def cmd_shell(args: argparse.Namespace) -> int:
     print(
             "Commands: load FILE, generate DESCRIPTION FILE, "
             "update [--patch-mode] [--dry-run] [--strict true|false] INSTRUCTION, "
-                    "validate, run, preview [--with-particles] [--screenshot FILE], explore QUESTION, exit"
+                "validate, run, preview [--with-particles] [--screenshot FILE], "
+                "continue-to-run, explore QUESTION, exit"
     )
     print("Note: relative paths are resolved from the current directory first, then .build-temp/.")
 
@@ -1792,6 +1852,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
             return 0
 
         if line == "help":
+            preview_runtime.discard_pending_simulation()
             print("Commands:")
             print("  load FILE                       - Load an existing config file")
             print("  generate DESCRIPTION FILE       - Generate new config via LLM and save to FILE")
@@ -1806,6 +1867,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
             print("  preview                         - Render geometry/BC preview (requires pyvista)")
             print("  preview --with-particles        - Run particle generation and overlay particles")
             print("  preview --screenshot FILE        - Save a screenshot to FILE instead of interactive window")
+            print("  continue-to-run                 - Finish and run the retained particle preview simulation")
             print("  run                             - Run simulation from loaded config")
             print("  exit                            - Exit shell")
             continue
@@ -1824,6 +1886,11 @@ def cmd_shell(args: argparse.Namespace) -> int:
             continue
 
         cmd = parts[0]
+
+        # A retained simulation has exactly one follow-up command. Any other
+        # command abandons it and lets the native wrapper release its state.
+        if cmd != "continue-to-run":
+            preview_runtime.discard_pending_simulation()
 
         if cmd == "load":
             if len(parts) < 2:
@@ -1988,6 +2055,10 @@ def cmd_shell(args: argparse.Namespace) -> int:
             )
             if rc == 0:
                 print("ℹ️ Preview window is persistent in shell mode; run `preview` again after edits.")
+            continue
+
+        if cmd == "continue-to-run":
+            _ = preview_runtime.continue_to_run()
             continue
 
         if cmd == "run":
@@ -2248,7 +2319,9 @@ def _parse_shell_ai_cli_style(text: str) -> list[str] | None:
         return None
 
     command = parts[0][1:]
-    valid_commands = {"generate", "validate", "update", "run", "preview", "explore", "shell"}
+    valid_commands = {
+        "generate", "validate", "update", "run", "preview", "continue-to-run", "explore", "shell"
+    }
     if command not in valid_commands:
         return None
 

--- a/sphinxsim/sph_simulation/dynamics_builder/thermal_dynamics_builder.hpp
+++ b/sphinxsim/sph_simulation/dynamics_builder/thermal_dynamics_builder.hpp
@@ -30,7 +30,7 @@ void ThermalDynamicsBuilder::buildThermalBoundaryCondition(
         return;
     }
 
-    std::runtime_error(
+    throw std::runtime_error(
         "Error: the boundary type is not supported in buildThermalBoundaryCondition.");
 }
 //=================================================================================================//

--- a/sphinxsim/sphinxsys/tutorials/sphinx/examples/example10_2D_thinPlate.rst
+++ b/sphinxsim/sphinxsys/tutorials/sphinx/examples/example10_2D_thinPlate.rst
@@ -161,14 +161,14 @@ are defined.
 
 	/** Creat a plate body. */
 	Plate *plate_body = new Plate(system, "PlateBody", new ParticleAdaptation(1.15, 0), new ParticleGeneratorDirect());
-	/** elastic soild material properties */
+	/** elastic solid material properties */
 	PlateMaterial *plate_material = new PlateMaterial();
 	/** Creat particles for the elastic body. */
 	ShellParticles plate_body_particles(plate_body, plate_material, PT);
 
 When defining :code:`plate_body`, four parameters are inputed.
 In :code:`ParticleAdaptation(1.15, 0)`, 1.15 is the smooth length ratio, 
-which means the cutoff radius for searching neighbor particls is 2.3 * :code:`resolution_ref`.
+which means the cutoff radius for searching neighbor particles is 2.3 * :code:`resolution_ref`.
 And 0 is global refinement level, which means the particle spacing is still :code:`resolution_ref`.
 If 0 is changed to 1, the particle spacing will be half :code:`resolution_ref`.
 And then the observer body and contact map are defined.

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -486,7 +486,7 @@ class ConfigVisualizer:
         if self.config.solid_bodies:
             lines.extend(["Solid", ""])
             for body in self.config.solid_bodies:
-                append_wrapped(f"{body.name}  (Soild)", indent="  ")
+                append_wrapped(f"{body.name}  (Solid)", indent="  ")
             lines.append("")
 
         if not body_information and not self.config.solid_bodies:

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -229,6 +229,8 @@ class ConfigVisualizer:
         self._vtp_dir: Path | None = None
         self._shape_bounds_cache: dict[str, Any] | None = None
         self._annotation_label_actors: list[dict[str, Any]] = []
+        self._particle_simulation: Any | None = None
+        self._particle_runtime_config_path: Path | None = None
 
     def _spatial_dim(self) -> int:
         """Return the spatial dimension (2 or 3) inferred from the config.
@@ -289,6 +291,16 @@ class ConfigVisualizer:
     def annotation_label_actors(self) -> list[dict[str, Any]]:
         """Label actors created by the latest preview population pass."""
         return list(self._annotation_label_actors)
+
+    def take_particle_simulation(self) -> tuple[Any, Path] | None:
+        """Transfer a generated-particle simulation and its runtime config."""
+        simulation = self._particle_simulation
+        runtime_config_path = self._particle_runtime_config_path
+        self._particle_simulation = None
+        self._particle_runtime_config_path = None
+        if simulation is None or runtime_config_path is None:
+            return None
+        return simulation, runtime_config_path
 
     # ------------------------------------------------------------------
     # Public API
@@ -562,7 +574,12 @@ class ConfigVisualizer:
         """
         if self.config_path is None:
             self._shape_bounds_cache = None
+            self._particle_simulation = None
+            self._particle_runtime_config_path = None
             return None
+
+        self._particle_simulation = None
+        self._particle_runtime_config_path = None
 
         try:
             sph = load_sphinxsys_core_nd(ndim)
@@ -617,11 +634,18 @@ class ConfigVisualizer:
                     self._shape_bounds_cache = sim.getShapeBounds()
                 except Exception:
                     self._shape_bounds_cache = None               
+                self._particle_simulation = sim
+                self._particle_runtime_config_path = runtime_config_path
         except Exception:
             self._shape_bounds_cache = None
+            self._particle_simulation = None
+            self._particle_runtime_config_path = None
             return None
         finally:
-            if runtime_config_path is not None:
+            if (
+                runtime_config_path is not None
+                and runtime_config_path != self._particle_runtime_config_path
+            ):
                 try:
                     runtime_config_path.unlink()
                 except OSError:

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -112,7 +112,7 @@ def _legend_entries_for_config(
         elif any(body.name == body_name for body in config.continuum_bodies):
             label = "Continuum particles"
         elif any(body.name == body_name for body in config.solid_bodies):
-            label = "Rigid-boundary particles"
+            label = "Solid particles"
         else:
             label = f"Particles: {body_name}"
         key = (label, colour)
@@ -121,7 +121,7 @@ def _legend_entries_for_config(
             seen.add(key)
 
     if config.solid_bodies:
-        entries.append(("Rigid boundary", _SOLID_COLOUR))
+        entries.append(("Solid", _SOLID_COLOUR))
 
     return entries
 
@@ -472,9 +472,9 @@ class ConfigVisualizer:
             lines.append("")
 
         if self.config.solid_bodies:
-            lines.extend(["Rigid boundaries", ""])
+            lines.extend(["Solid", ""])
             for body in self.config.solid_bodies:
-                append_wrapped(f"{body.name}  (Rigid boundary)", indent="  ")
+                append_wrapped(f"{body.name}  (Soild)", indent="  ")
             lines.append("")
 
         if not body_information and not self.config.solid_bodies:

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -693,13 +693,14 @@ class ConfigVisualizer:
                 suffix = stem[len(prefix):]
                 if suffix.startswith("ite_"):
                     suffix = suffix[len("ite_"):]
-                if not suffix.isdigit():
+                try:
+                    sequence = float(suffix)
+                except ValueError:
                     continue
 
-                step = int(suffix)
                 previous = latest.get(body_name)
-                if previous is None or step >= previous[0]:
-                    latest[body_name] = (step, path)
+                if previous is None or sequence >= previous[0]:
+                    latest[body_name] = (sequence, path)
                 break
 
         return {body_name: item[1] for body_name, item in latest.items()}
@@ -918,6 +919,7 @@ class ConfigVisualizer:
 
             plotter.add_mesh(
                 particle_mesh,
+                name=f"particle-preview-{body_name}",
                 color=_body_colour(body_name, config),
                 opacity=0.95,
                 style="points",

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1108,9 +1108,20 @@ class TestShellPreview:
         runtime._pending_runtime_config_path = runtime_config_path
 
         assert runtime.continue_to_run() == 0
+        assert runtime._live_run_thread is not None
+        runtime._live_run_thread.join()
         assert calls == ["build", "initialize", "run"]
         assert runtime._pending_simulation is None
         assert not runtime_config_path.exists()
+
+    def test_shell_continue_to_run_accepts_refresh_interval(self):
+        from sphinxsim import cli as cli_mod
+
+        with patch.object(cli_mod._ShellPreviewRuntime, "continue_to_run", return_value=0) as continue_to_run:
+            with patch("builtins.input", side_effect=["continue-to-run --refresh-interval 2.5", "exit"]):
+                assert main(["shell"]) == 0
+
+        continue_to_run.assert_called_once_with(2.5)
 
     def test_shell_runtime_releases_pending_simulation_for_other_command(self, build_temp_path):
         _, rel = self._write_config(build_temp_path)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1086,6 +1086,51 @@ class TestShellPreview:
         _, kwargs = mock_show_or_update.call_args
         assert kwargs.get("with_particles") is True
 
+    def test_shell_runtime_continues_retained_particle_simulation(self, tmp_path):
+        from sphinxsim import cli as cli_mod
+
+        calls: list[str] = []
+
+        class FakeSimulation:
+            def buildSimulation(self):
+                calls.append("build")
+
+            def initializeSimulation(self):
+                calls.append("initialize")
+
+            def run(self):
+                calls.append("run")
+
+        runtime = cli_mod._ShellPreviewRuntime()
+        runtime._pending_simulation = FakeSimulation()
+        runtime_config_path = tmp_path / "sphinxsim_preview.json"
+        runtime_config_path.write_text("{}")
+        runtime._pending_runtime_config_path = runtime_config_path
+
+        assert runtime.continue_to_run() == 0
+        assert calls == ["build", "initialize", "run"]
+        assert runtime._pending_simulation is None
+        assert not runtime_config_path.exists()
+
+    def test_shell_runtime_releases_pending_simulation_for_other_command(self, build_temp_path):
+        _, rel = self._write_config(build_temp_path)
+        pending_simulation = object()
+
+        with patch.dict(sys.modules, {"pyvista": MagicMock()}):
+            with patch(
+                "sphinxsim.cli._ShellPreviewRuntime.show_or_update",
+                return_value=0,
+            ):
+                with patch.object(
+                    __import__("sphinxsim.cli", fromlist=["_ShellPreviewRuntime"])._ShellPreviewRuntime,
+                    "discard_pending_simulation",
+                ) as discard:
+                    with patch("builtins.input", side_effect=[f"load {rel}", "preview", "exit"]):
+                        rc = main(["shell"])
+
+        assert rc == 0
+        assert discard.call_count >= 2
+
     def test_shell_runtime_does_not_require_legacy_view_widgets(self, tmp_path, monkeypatch):
         from sphinxsim import cli as cli_mod
 
@@ -1093,7 +1138,7 @@ class TestShellPreview:
         runtime = cli_mod._ShellPreviewRuntime()
 
         class FakeVisualizer:
-            _bounds_sim = None
+            used_cpp_bounds = False
 
             def __init__(self, *args, **kwargs):
                 pass
@@ -1158,7 +1203,7 @@ class TestShellPreview:
         visualizer_paths: list[Path] = []
 
         class FakeVisualizer:
-            _bounds_sim = None
+            used_cpp_bounds = False
 
             def __init__(self, _config, _project_root, *, config_path, off_screen):
                 visualizer_paths.append(config_path)
@@ -1248,7 +1293,7 @@ class TestShellPreview:
         config_path = tmp_path / "config.json"
 
         class FakeVisualizer:
-            _bounds_sim = None
+            used_cpp_bounds = False
 
             def __init__(self, *args, **kwargs):
                 pass

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -289,7 +289,7 @@ class TestPreviewLegend:
 
         assert "Weakly compressible fluid" in labels
         assert "Granular material" not in labels
-        assert "Rigid boundary" in labels
+        assert "Solid" in labels
 
 
 class TestOrientedBoxLabel:


### PR DESCRIPTION
This pull request introduces a new `continue-to-run` shell command to the CLI, allowing users to resume and run a simulation retained by a prior `preview --with-particles` command. It also adds live particle cloud refresh in the Qt-based preview window at a configurable interval while the simulation runs. The changes also clarify documentation, improve resource management, and fix a minor bug in the C++ code. Below are the most important changes:

---

### New CLI Features

* Added `continue-to-run [--refresh-interval SECONDS]` shell command to run the simulation retained by `preview --with-particles`, with live preview refresh every N seconds (default 10), and robust resource cleanup. [[1]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R662-R675) [[2]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R707-R854) [[3]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R1884-R1900) [[4]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6L1771-R1948) [[5]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R1972) [[6]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R1987-R1988) [[7]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R2008-R2012) [[8]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R2178-R2196) [[9]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6L2251-R2457)
* The live refresh feature uses a Qt timer to periodically reload particle VTP files and update the preview, ensuring thread safety and UI responsiveness.

### Documentation Updates

* Updated `docs/cli-usage.md` and `docs/visualization.md` to document the new `continue-to-run` command, its usage, and how retained simulations are managed. [[1]](diffhunk://#diff-db1edc34e2669e38a73d617574cd04b8790a911cc42f5033d40b7e5903fcef27R135) [[2]](diffhunk://#diff-db1edc34e2669e38a73d617574cd04b8790a911cc42f5033d40b7e5903fcef27R146-R147) [[3]](diffhunk://#diff-4930ef191171ffe17a17d477fe38a11f97f107e3621c11593191ac05f8e8d1a4R158-R189)
* Expanded the design and test documentation in `.github/skills/visualization/SKILL.md` to cover the new workflow and test requirements for particle preview continuation. [[1]](diffhunk://#diff-3aa4c5b5d2229d7e6215da7da7ce7cf31fe5ddb0e0ed1991cc604d79e256a5a9R64-R74) [[2]](diffhunk://#diff-3aa4c5b5d2229d7e6215da7da7ce7cf31fe5ddb0e0ed1991cc604d79e256a5a9R141-R153)

### Resource Management and Robustness

* Ensured that only one command can follow a retained simulation; any other command discards the simulation and deletes its temporary config, preventing resource leaks. [[1]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R662-R675) [[2]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R707-R854) [[3]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R2008-R2012)
* Improved error handling and feedback for invalid usage, missing dependencies, or refresh intervals.

### C++ and Python API Fixes

* Added `py::gil_scoped_release()` to `SPHSimulation::run` binding for better threading performance.
* Fixed a missing `throw` in C++ error handling for unsupported thermal boundary conditions.

### Minor Improvements

* Updated legend label for solid particles in the preview for clarity.
* Improved fallback logic for geometry mode labeling in the preview.

---