### PR TITLE
Xiangyu/json editor revision

### DIFF
--- a/sphinxsim/cli.py
+++ b/sphinxsim/cli.py
@@ -199,6 +199,103 @@ def _config_spatial_dim(config: SimulationConfig) -> int:
     return 3
 
 
+def _new_json_editor_list_item(path: tuple[Any, ...], spatial_dim: int) -> Any:
+    """Return an editable starter value for an empty JSON editor list."""
+    normalized_path = tuple(part for part in path if not isinstance(part, int))
+    vector = [0.0] * spatial_dim
+    unit_vector = [1.0] * spatial_dim
+    transform = {
+        "translation": vector,
+        "rotation_angle": 0.0,
+    }
+    if spatial_dim == 3:
+        transform["rotation_axis"] = [0.0, 0.0, 1.0]
+
+    templates: dict[tuple[Any, ...], Any] = {
+        ("characteristic_dimensions",): {
+            "name": "Length",
+            "value": 1.0,
+            "hint": "Characteristic length",
+        },
+        ("geometries", "primitives"): {
+            "name": "New primitive",
+            "type": "box",
+            "half_size": unit_vector,
+            "transform": transform,
+        },
+        ("geometries", "shapes"): {
+            "name": "New shape",
+            "type": "bounding_box",
+            "lower_bound": vector,
+            "upper_bound": unit_vector,
+        },
+        ("geometries", "shapes", "polygons"): {
+            "operation": "union",
+            "type": "bounding_box",
+            "lower_bound": vector,
+            "upper_bound": unit_vector,
+        },
+        ("geometries", "oriented_boxes"): {
+            "name": "New region",
+            "type": "region",
+            "half_size": unit_vector,
+            "transform": transform,
+        },
+        ("particle_generation", "settings", "bodies"): {"name": "New body"},
+        ("particle_generation", "settings", "relaxation_constraints"): {
+            "body_name": "",
+            "oriented_box": "",
+            "type": "",
+        },
+        ("fluid_bodies",): {
+            "name": "New fluid body",
+            "material": {"type": "weakly_compressible_fluid", "density": 1000.0},
+        },
+        ("continuum_bodies",): {
+            "name": "New continuum body",
+            "material": {
+                "type": "general_continuum",
+                "density": 1000.0,
+                "sound_speed": 100.0,
+                "youngs_modulus": 1000000.0,
+                "poisson_ratio": 0.3,
+            },
+        },
+        ("solid_bodies",): {
+            "name": "New solid body",
+            "material": {"type": "rigid_body"},
+        },
+        ("observers",): {
+            "name": "New observer",
+            "observed_body": "",
+            "variable": {"real_type": "Pressure"},
+            "positions": [vector],
+        },
+        ("fluid_boundary_conditions",): {
+            "body_name": "",
+            "oriented_box": "",
+            "type": "emitter",
+            "inflow_speed": 1.0,
+        },
+        ("body_constraints",): {"body_name": "", "type": "fixed"},
+        ("initial_conditions",): {
+            "body_name": "",
+            "assignments": [{"variable": {"real_type": "Pressure"}, "value": 0.0}],
+        },
+        ("initial_conditions", "assignments"): {
+            "variable": {"real_type": "Pressure"},
+            "value": 0.0,
+        },
+        ("extra_state_recording",): {
+            "name": "New recording",
+            "variables": [{"real_type": ["Pressure"]}],
+        },
+        ("extra_state_recording", "variables"): {"real_type": ["Pressure"]},
+        ("energy_recording",): {"name": "New energy recording", "body": ""},
+    }
+    return copy.deepcopy(templates.get(normalized_path, {}))
+
+
 # ---------------------------------------------------------------------------
 # Sub-command handlers
 # ---------------------------------------------------------------------------
@@ -644,6 +741,30 @@ def _resolve_preview_config_path(config_file: str) -> Path:
     return cwd_path if cwd_path.exists() else build_temp_path
 
 
+def _set_windows_dark_title_bar(window: Any) -> None:
+    """Request Windows dark mode for a Qt top-level window's native title bar."""
+    if sys.platform != "win32":
+        return
+
+    try:
+        import ctypes
+
+        hwnd = int(window.winId())
+        enabled = ctypes.c_int(1)
+        dwmapi = ctypes.windll.dwmapi
+        for attribute in (20, 19):  # Windows 10 build-dependent dark-mode IDs.
+            result = dwmapi.DwmSetWindowAttribute(
+                hwnd,
+                attribute,
+                ctypes.byref(enabled),
+                ctypes.sizeof(enabled),
+            )
+            if result == 0:
+                break
+    except Exception:
+        pass
+
+
 class _ShellPreviewRuntime:
     """Persistent shell preview runtime.
 
@@ -722,6 +843,25 @@ class _ShellPreviewRuntime:
         app_window = getattr(self.plotter, "app_window", None)
         if app_window is None:
             return True
+        _set_windows_dark_title_bar(app_window)
+        app_window.setStyleSheet(
+            "QMainWindow { background: #181a1f; }"
+            "QMenuBar { background: #202329; color: #e6e8ec; border-bottom: 1px solid #3b4049; }"
+            "QMenuBar::item { padding: 5px 9px; background: transparent; }"
+            "QMenuBar::item:selected { background: #30343c; color: #ffffff; }"
+            "QMenu { background: #24272d; color: #e6e8ec; border: 1px solid #454b55; }"
+            "QMenu::item { padding: 5px 24px 5px 10px; }"
+            "QMenu::item:selected { background: #315f8c; color: #ffffff; }"
+            "QToolBar { background: #202329; border: 0; border-bottom: 1px solid #3b4049; spacing: 3px; }"
+            "QToolBar QToolButton { min-width: 26px; min-height: 26px; padding: 2px; "
+            "background: #24272d; color: #f0f2f5; border: 1px solid #4a505b; border-radius: 3px; }"
+            "QToolBar QToolButton:hover { background: #30343c; color: #ffffff; border-color: #75a9d0; }"
+            "QToolBar QToolButton:pressed { background: #315f8c; color: #ffffff; border-color: #80bde8; }"
+            "QToolBar QToolButton:disabled { background: #202329; color: #6f7680; border-color: #343a43; }"
+            "QStatusBar { background: #202329; color: #c8ccd4; border-top: 1px solid #3b4049; }"
+            "QSplitter::handle { background: #3b4049; }"
+            "QSplitter::handle:hover { background: #5794cf; }"
+        )
 
         dock = QtWidgets.QDockWidget("Simulation Properties", app_window)
         dock.setObjectName("sphinxsim-json-editor")
@@ -744,39 +884,50 @@ class _ShellPreviewRuntime:
             "QToolButton {"
             "    min-height: 24px;"
             "    padding: 2px 5px;"
-            "    border: 1px solid transparent;"
+            "    border: 1px solid #4a505b;"
             "    border-radius: 3px;"
-            "    background: transparent;"
-            "    color: #c8ccd4;"
+            "    background: #24272d;"
+            "    color: #d7dae0;"
             "}"
             "QToolButton:hover {"
             "    background: #30343c;"
-            "    border: 1px solid #4a505b;"
+            "    border: 1px solid #61707e;"
             "    color: #ffffff;"
             "}"
             "QToolButton:pressed {"
             "    background: #3a404a;"
-            "    border: 1px solid #616a78;"
+            "    border: 1px solid #7b8997;"
             "    color: #ffffff;"
             "}"
             "QToolButton:disabled {"
-            "    background: transparent;"
-            "    border: 1px solid transparent;"
+            "    background: #202329;"
+            "    border: 1px solid #343a43;"
             "    color: #686e79;"
+            "}"
+            "QToolButton#sphinxsim-json-editor-list-action {"
+            "    min-height: 28px;"
+            "    font-weight: 600;"
+            "    background: #2f6f9f;"
+            "    border: 1px solid #235a84;"
+            "    color: #ffffff;"
+            "}"
+            "QToolButton#sphinxsim-json-editor-list-action:hover {"
+            "    background: #245d88;"
+            "    border-color: #164969;"
+            "}"
+            "QToolButton#sphinxsim-json-editor-list-action:pressed {"
+            "    background: #1c4c70;"
+            "    border-color: #123b59;"
+            "}"
+            "QToolButton#sphinxsim-json-editor-list-action:disabled {"
+            "    background: #25313b;"
+            "    border: 1px solid #374956;"
+            "    color: #788895;"
             "}"
         )
         layout = QtWidgets.QVBoxLayout(content)
         layout.setContentsMargins(8, 8, 8, 8)
         layout.setSpacing(8)
-        hint = QtWidgets.QLabel("<b style='color:#ffffff'>Use Ctrl+S to save changes</b>")
-        hint.setWordWrap(True)
-        hint.setAlignment(
-            QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter
-        )
-        hint.setStyleSheet(
-            "padding: 8px 10px; border: 1px solid #3d6f9e; border-radius: 4px; "
-            "background: #1f3042; color: #cbd8e6;"
-        )
         filter_box = QtWidgets.QLineEdit(content)
         filter_box.setObjectName("sphinxsim-json-editor-filter")
         filter_box.setPlaceholderText("Filter settings…")
@@ -806,6 +957,15 @@ class _ShellPreviewRuntime:
         move_up_button.setText("Move up")
         move_down_button = QtWidgets.QToolButton(content)
         move_down_button.setText("Move down")
+        list_action_buttons = (
+            add_item_button,
+            duplicate_item_button,
+            remove_item_button,
+            move_up_button,
+            move_down_button,
+        )
+        for button in list_action_buttons:
+            button.setObjectName("sphinxsim-json-editor-list-action")
         tool_buttons = (
             expand_button,
             collapse_button,
@@ -829,7 +989,7 @@ class _ShellPreviewRuntime:
             row = 0 if index < 5 else 1
             column = index if index < 5 else index - 5
             tools_grid.addWidget(button, row, column)
-            button.setVisible(False)
+            button.setVisible(True)
 
         for column in range(5):
             tools_grid.setColumnStretch(column, 1)
@@ -862,9 +1022,12 @@ class _ShellPreviewRuntime:
         status.setAlignment(
             QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter
         )
-        status.setStyleSheet("color: #aeb4bf;")
-        layout.addWidget(hint)
+        status.setStyleSheet(
+            "padding: 7px 9px; border: 1px solid #3d6f9e; border-radius: 4px; "
+            "background: #1f3042; color: #d9e8f5;"
+        )
         layout.addWidget(filter_box)
+        layout.addLayout(tools_grid)
         layout.addWidget(tree, 1)
         layout.addWidget(status)
         dock.setWidget(content)
@@ -1032,7 +1195,12 @@ class _ShellPreviewRuntime:
                 widget.setText(json.dumps(value, ensure_ascii=False))
             return widget
 
-        def populate_editor(text: str, *, reset_history: bool = False) -> None:
+        def populate_editor(
+            text: str,
+            *,
+            reset_history: bool = False,
+            expand_defaults: bool = True,
+        ) -> None:
             iterator = QtWidgets.QTreeWidgetItemIterator(tree)
             while iterator.value() is not None:
                 previous_item = iterator.value()
@@ -1059,7 +1227,10 @@ class _ShellPreviewRuntime:
                     item = _new_tree_item(parent, _display_label(label), f"Object · {len(value)}")
                     item.setData(0, QtCore.Qt.ItemDataRole.UserRole, path_key)
                     editor_state["item_paths"][id(item)] = path
-                    item.setExpanded(path_key in editor_state["expanded_paths"] or depth < 2)
+                    item.setExpanded(
+                        path_key in editor_state["expanded_paths"]
+                        or (expand_defaults and depth < 2)
+                    )
                     font = item.font(0)
                     font.setBold(True)
                     item.setFont(0, font)
@@ -1071,7 +1242,10 @@ class _ShellPreviewRuntime:
                     item.setData(0, QtCore.Qt.ItemDataRole.UserRole, path_key)
                     editor_state["item_paths"][id(item)] = path
                     editor_state["list_paths"].add(path)
-                    item.setExpanded(path_key in editor_state["expanded_paths"] or depth < 2)
+                    item.setExpanded(
+                        path_key in editor_state["expanded_paths"]
+                        or (expand_defaults and depth < 2)
+                    )
                     font = item.font(0)
                     font.setBold(True)
                     item.setFont(0, font)
@@ -1233,9 +1407,11 @@ class _ShellPreviewRuntime:
                 if operation == "add" and path in editor_state["list_paths"]:
                     target_list = _payload_at(path)
                     if not target_list:
-                        status.setText("Cannot infer a new entry for an empty list; edit [] directly to add its first item.")
-                        return
-                    target_list.append(copy.deepcopy(target_list[-1]))
+                        target_list.append(
+                            _new_json_editor_list_item(path, _config_spatial_dim(config))
+                        )
+                    else:
+                        target_list.append(copy.deepcopy(target_list[-1]))
                 elif path[:-1] in editor_state["list_paths"] and isinstance(path[-1], int):
                     target_list = _payload_at(path[:-1])
                     index = path[-1]
@@ -1256,8 +1432,11 @@ class _ShellPreviewRuntime:
                 return
 
             editor_state["undo_stack"].append(before_edit)
-            editor_state["expanded_paths"].add(".".join(str(part) for part in path[:-1]))
-            populate_editor(json.dumps(editor_state["payload"], indent=2, ensure_ascii=False))
+            editor_state["expanded_paths"].add(".".join(str(part) for part in path))
+            populate_editor(
+                json.dumps(editor_state["payload"], indent=2, ensure_ascii=False),
+                expand_defaults=False,
+            )
             _mark_dirty()
             update_array_actions()
 

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -35,10 +35,11 @@ from sphinxsim.bindings.loader import load_sphinxsys_core_nd
 # Keep this in data coordinates so the arrow follows the absolute model scale.
 GRAVITY_ARROW_LENGTH_RATIO = 1.0 / 5.0
 PREVIEW_MAIN_VIEWPORT_WIDTH = 0.76
-PREVIEW_SIDEBAR_BACKGROUND = (0.93, 0.93, 0.93)
-PREVIEW_TEXT_COLOUR = (0.12, 0.12, 0.12)
-PREVIEW_AXIS_COLOUR = (0.25, 0.25, 0.25)
-PREVIEW_GRAVITY_TEXT_COLOUR = (0.0, 0.35, 0.38)
+PREVIEW_MAIN_BACKGROUND = (0.09, 0.10, 0.12)
+PREVIEW_SIDEBAR_BACKGROUND = (0.12, 0.14, 0.17)
+PREVIEW_TEXT_COLOUR = (0.90, 0.92, 0.95)
+PREVIEW_AXIS_COLOUR = (0.55, 0.59, 0.64)
+PREVIEW_GRAVITY_TEXT_COLOUR = (0.30, 0.82, 0.85)
 
 if TYPE_CHECKING:
     from sphinxsim.config.schemas import (
@@ -385,10 +386,10 @@ class ConfigVisualizer:
             if len(renderers) < 2:
                 return False
             try:
-                plotter.set_background("white")
+                plotter.set_background(PREVIEW_MAIN_BACKGROUND)
             except AttributeError:
                 pass
-            renderers[0].SetBackground((1.0, 1.0, 1.0))
+            renderers[0].SetBackground(PREVIEW_MAIN_BACKGROUND)
             renderers[1].SetBackground(PREVIEW_SIDEBAR_BACKGROUND)
             renderers[0].SetViewport(0.0, 0.0, PREVIEW_MAIN_VIEWPORT_WIDTH, 1.0)
             renderers[1].SetViewport(PREVIEW_MAIN_VIEWPORT_WIDTH, 0.0, 1.0, 1.0)
@@ -1033,7 +1034,7 @@ class ConfigVisualizer:
                 [observer_short_label(observer_index)],
                 font_size=9,
                 text_color=(0.55, 0.0, 0.45),
-                background_color=(0.94, 0.94, 0.94),
+                background_color=PREVIEW_SIDEBAR_BACKGROUND,
                 background_opacity=0.96,
             )
 
@@ -1047,7 +1048,7 @@ class ConfigVisualizer:
             # A larger legend viewport gives the rectangular material swatches
             # enough visual weight beside their labels.
             size=(0.28, 0.10),
-            bcolor="white",
+            bcolor=PREVIEW_SIDEBAR_BACKGROUND,
             border=True,
             loc="upper left",
             background_opacity=0.88,
@@ -1061,7 +1062,7 @@ class ConfigVisualizer:
             except AttributeError:
                 pass
         try:
-            plotter.set_background("white")
+            plotter.set_background(PREVIEW_MAIN_BACKGROUND)
         except AttributeError:
             pass
 

--- a/sphinxsim/visualization/preview.py
+++ b/sphinxsim/visualization/preview.py
@@ -1049,7 +1049,7 @@ class ConfigVisualizer:
             # enough visual weight beside their labels.
             size=(0.28, 0.10),
             bcolor=PREVIEW_SIDEBAR_BACKGROUND,
-            border=True,
+            border=False,
             loc="upper left",
             background_opacity=0.88,
         )
@@ -1058,7 +1058,7 @@ class ConfigVisualizer:
                 text_property = legend.GetEntryTextProperty()
                 text_property.SetFontSize(5)
                 text_property.SetBold(False)
-                text_property.SetColor(0.1, 0.1, 0.1)
+                text_property.SetColor(PREVIEW_TEXT_COLOUR)
             except AttributeError:
                 pass
         try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 
 import sphinxsim
-from sphinxsim.cli import _config_spatial_dim, _load_config, main
+from sphinxsim.cli import _config_spatial_dim, _load_config, _new_json_editor_list_item, main
 from sphinxsim.cli import _build_parser
 from sphinxsim.llm.common import LLMRepairWarning
 
@@ -208,6 +208,25 @@ class TestSpatialDimension:
     def test_infers_3d_from_domain(self):
         config = sphinxsim.SimulationConfig.model_validate(_valid_3d_data())
         assert _config_spatial_dim(config) == 3
+
+
+class TestJsonEditorListItems:
+    def test_empty_shapes_list_gets_an_editable_shape(self):
+        item = _new_json_editor_list_item(("geometries", "shapes"), spatial_dim=2)
+
+        assert item == {
+            "name": "New shape",
+            "type": "bounding_box",
+            "lower_bound": [0.0, 0.0],
+            "upper_bound": [1.0, 1.0],
+        }
+
+    def test_empty_nested_list_uses_a_schema_aware_object(self):
+        item = _new_json_editor_list_item(
+            ("initial_conditions", 0, "assignments"), spatial_dim=3
+        )
+
+        assert item == {"variable": {"real_type": "Pressure"}, "value": 0.0}
 
 
 class TestCLIGenerate:

--- a/tests/test_simulation/test_2d_simulation/data/dambreak.json
+++ b/tests/test_simulation/test_2d_simulation/data/dambreak.json
@@ -105,16 +105,6 @@
         "multi_species_phases": []
       },
       "is_moving": false
-    },
-    {
-      "name": "Obstacle",
-      "material": {
-        "type": "rigid_body",
-        "species": [],
-        "pure_phases": [],
-        "multi_species_phases": []
-      },
-      "is_moving": false
     }
   ],
   "gravity": [

--- a/tests/test_simulation/test_2d_simulation/data/dambreak.json
+++ b/tests/test_simulation/test_2d_simulation/data/dambreak.json
@@ -16,17 +16,37 @@
       "hint": "fluid_bodies[name=WaterBody].material.density"
     }
   ],
-
   "simulation_type": "fluid_dynamics",
-
+  "log_level": "info",
   "geometries": {
-    "global_resolution": { "particle_spacing": 0.025 },
+    "global_resolution": {
+      "particle_spacing": 0.025
+    },
+    "primitives": [],
     "shapes": [
       {
         "name": "WaterBody",
         "type": "bounding_box",
-        "lower_bound": [0.0, 0.0],
-        "upper_bound": [2.0, 1.0]
+        "lower_bound": [
+          0.0,
+          0.0
+        ],
+        "upper_bound": [
+          2.0,
+          1.0
+        ]
+      },
+      {
+        "name": "Obstacle",
+        "type": "bounding_box",
+        "lower_bound": [
+          3.0,
+          0.5
+        ],
+        "upper_bound": [
+          3.5,
+          1.0
+        ]
       },
       {
         "name": "WallBoundary",
@@ -35,82 +55,143 @@
           {
             "operation": "union",
             "type": "container_box",
-            "inner_lower_bound": [0.0, 0.0],
-            "inner_upper_bound": [5.366, 5.366],
+            "inner_lower_bound": [
+              0.0,
+              0.0
+            ],
+            "inner_upper_bound": [
+              5.366,
+              5.366
+            ],
             "thickness": 0.1
           }
         ]
       }
-    ]
+    ],
+    "oriented_boxes": []
   },
-
   "particle_generation": {
     "build_and_run": true,
     "settings": {
       "bodies": [
         {
-          "name": "WaterBody"
+          "name": "WaterBody",
+          "blockers": [],
+          "box_shape_inserts": [],
+          "cylinder_shape_inserts": []
         },
         {
           "name": "WallBoundary",
+          "blockers": [],
+          "box_shape_inserts": [],
+          "cylinder_shape_inserts": [],
+          "solid_body": {}
+        },
+        {
+          "name": "Obstacle",
+          "blockers": [],
+          "box_shape_inserts": [],
+          "cylinder_shape_inserts": [],
           "solid_body": {}
         }
       ],
+      "relaxation_constraints": [],
       "relaxation_parameters": {
         "total_iterations": 1000
       }
     }
   },
-
   "fluid_bodies": [
     {
       "name": "WaterBody",
       "material": {
         "type": "weakly_compressible_fluid",
-        "density": 1.0
+        "density": 1.0,
+        "species": [],
+        "pure_phases": [],
+        "multi_species_phases": []
       }
     }
   ],
-
+  "continuum_bodies": [],
   "solid_bodies": [
     {
       "name": "WallBoundary",
       "material": {
-        "type": "rigid_body"
-      }
+        "type": "rigid_body",
+        "species": [],
+        "pure_phases": [],
+        "multi_species_phases": []
+      },
+      "is_moving": false
+    },
+    {
+      "name": "Obstacle",
+      "material": {
+        "type": "rigid_body",
+        "species": [],
+        "pure_phases": [],
+        "multi_species_phases": []
+      },
+      "is_moving": false
     }
   ],
-
-  "gravity": [0.0, -1.0],
-
+  "gravity": [
+    0.0,
+    -1.0
+  ],
   "observers": [
     {
       "name": "FluidObserver",
       "observed_body": "WaterBody",
-      "variable": { "real_type": "Pressure" },
-      "positions": [[5.366, 0.2]]
+      "variable": {
+        "real_type": "Pressure"
+      },
+      "positions": [
+        [
+          5.366,
+          0.2
+        ]
+      ]
     }
   ],
-
+  "fluid_boundary_conditions": [],
+  "body_constraints": [],
+  "initial_conditions": [],
   "extra_state_recording": [
     {
       "name": "WaterBody",
-      "variables": [{ "real_type": ["Pressure"] }]
+      "variables": [
+        {
+          "real_type": [
+            "Pressure"
+          ]
+        }
+      ]
     },
     {
       "name": "WallBoundary",
-      "variables": [{ "vector_type": ["NormalDirection"] }]
+      "variables": [
+        {
+          "vector_type": [
+            "NormalDirection"
+          ]
+        }
+      ]
     }
   ],
-
+  "energy_recording": [],
   "solver_parameters": {
     "end_time": 20.0,
     "output_interval": 0.1,
     "screen_interval": 100,
+    "observation_interval": 200,
     "fluid_dynamics": {
       "acoustic_cfl": 0.6,
       "advection_cfl": 0.25,
+      "max_velocity_factor": 1.0,
       "surface_type": "free_surface",
+      "kernel_correction": "linear",
       "particle_sort_frequency": 100
     }
   }

--- a/tests/test_simulation/test_2d_simulation/data/dambreak.json
+++ b/tests/test_simulation/test_2d_simulation/data/dambreak.json
@@ -37,18 +37,6 @@
         ]
       },
       {
-        "name": "Obstacle",
-        "type": "bounding_box",
-        "lower_bound": [
-          3.0,
-          0.5
-        ],
-        "upper_bound": [
-          3.5,
-          1.0
-        ]
-      },
-      {
         "name": "WallBoundary",
         "type": "multipolygon",
         "polygons": [
@@ -82,13 +70,6 @@
         },
         {
           "name": "WallBoundary",
-          "blockers": [],
-          "box_shape_inserts": [],
-          "cylinder_shape_inserts": [],
-          "solid_body": {}
-        },
-        {
-          "name": "Obstacle",
           "blockers": [],
           "box_shape_inserts": [],
           "cylinder_shape_inserts": [],


### PR DESCRIPTION
This pull request introduces a dark mode UI theme for the simulation preview and JSON editor in the SphinxSim application, enhancing visual consistency and accessibility. It also improves the JSON editor's handling of empty lists by providing schema-aware starter values, and refines the test suite to cover these new behaviors.

**UI/UX Improvements:**

* Applied a cohesive dark theme to the simulation preview and JSON editor, including backgrounds, text, toolbars, and menus (`sphinxsim/visualization/preview.py`, `sphinxsim/cli.py`). [[1]](diffhunk://#diff-db912d8e4b8060d1382544609f6a27240a523776d364cd86778649d9470a545aL38-R42) [[2]](diffhunk://#diff-db912d8e4b8060d1382544609f6a27240a523776d364cd86778649d9470a545aL388-R392) [[3]](diffhunk://#diff-db912d8e4b8060d1382544609f6a27240a523776d364cd86778649d9470a545aL1036-R1037) [[4]](diffhunk://#diff-db912d8e4b8060d1382544609f6a27240a523776d364cd86778649d9470a545aL1050-R1052) [[5]](diffhunk://#diff-db912d8e4b8060d1382544609f6a27240a523776d364cd86778649d9470a545aL1060-R1065) [[6]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R744-R767) [[7]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R846-R864) [[8]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6L747-L779)
* Customized button styles, especially for list actions in the JSON editor, to improve clarity and accessibility (`sphinxsim/cli.py`). [[1]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6L747-L779) [[2]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R960-R968)

**JSON Editor Functionality:**

* Added `_new_json_editor_list_item` to provide schema-aware default entries when adding items to empty lists, improving usability and preventing errors (`sphinxsim/cli.py`). [[1]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6R202-R298) [[2]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6L1236-R1413)
* Updated list editing logic to use these starter values and ensure correct tree expansion and undo behavior (`sphinxsim/cli.py`). [[1]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6L1259-R1439) [[2]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6L1035-R1203) [[3]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6L1062-R1233) [[4]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6L1074-R1248) [[5]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6L832-R992) [[6]](diffhunk://#diff-71835c2cac7057a9df88fe05a05517259cbc4534eb3767144277ddcba9ebe9b6L865-R1030)

**Testing:**

* Added tests for the new schema-aware list item behavior in the JSON editor (`tests/test_cli.py`). [[1]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eL12-R12) [[2]](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR213-R231)

**Other:**

* Minor formatting and field additions to simulation test data for consistency (`tests/test_simulation/test_2d_simulation/data/dambreak.json`).

These changes collectively provide a more modern, accessible, and user-friendly interface for simulation configuration and preview.